### PR TITLE
Changes so Host runs on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Visual Studio
+obj/
+*.sln
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+.vs/
+packages/
+target/
+*.pdb
+packages.config
+CMakeSettings.json
+.vscode
+.cache
+
+
+# IntelliJ IDEA
+.idea
+
+# CMake common patterns
+build/
+cmake-build-*/
+
+
+# A place to store stuff and get it git ignored
+ignore/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.17)
+cmake_policy(SET CMP0100 NEW)  # handle .hh files
 project(CLAP C CXX)
 
 set(ENABLE_CLAP_GLUE TRUE CACHE BOOL "Enables the helper glue code")

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ the [draft](include/clap/ext/draft) folder.
 An extension comes with:
 - an header `#include <clap/ext/xxx.h>`
 - an extension identifier: `#define CLAP_EXT_XXX "clap/XXX"`
-- host interfaces are named like: `stuct clap_host_xxx`
-- plugin interfaces are named like: `stuct clap_plugin_xxx`
+- host interfaces are named like: `struct clap_host_xxx`
+- plugin interfaces are named like: `struct clap_plugin_xxx`
 - each methods must have a clear thread specification
 
 You can create your own extensions and share them, make sure that the extension identifier
@@ -86,3 +86,18 @@ and use to get a basic plugin experience:
 ## Examples
 
 Visit the [examples](examples) folder.
+
+## Building on various platforms
+
+### macOS
+
+To build the example host on macOS you need a few extra libraries, qt6, boost, portmidi and portaudio.
+These are all available by homebrew and the CMake setup will find them assuming a standard
+(/usr/local) homebrew setup. Before your first build do
+
+```shell
+brew install qt6
+brew install boost
+brew install portaudio
+brew install portmidi
+```

--- a/examples/host/CMakeLists.txt
+++ b/examples/host/CMakeLists.txt
@@ -4,9 +4,16 @@ set(CMAKE_AUTOMOC ON)
 find_package(Qt6Core REQUIRED)
 find_package(Qt6Widgets REQUIRED)
 
-#find_package(PkgConfig REQUIRED)
-#pkg_check_modules(PortAudio REQUIRED IMPORTED_TARGET portaudio-2.0)
-#pkg_check_modules(PortMidi REQUIRED IMPORTED_TARGET portmidi)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PortAudio REQUIRED IMPORTED_TARGET portaudio-2.0)
+if (UNIX AND NOT APPLE)
+  pkg_check_modules(PortMidi REQUIRED IMPORTED_TARGET portmidi)
+endif()
+if (APPLE)
+  add_library(portmidi INTERFACE)
+  target_link_options(portmidi INTERFACE -L/usr/local/lib)
+  target_link_libraries(portmidi INTERFACE libportmidi.dylib)
+endif()
 
 add_executable(clap-host
   application.cc

--- a/examples/host/plugin-host.cc
+++ b/examples/host/plugin-host.cc
@@ -237,7 +237,7 @@ void PluginHost::setParentWindow(WId parentWindow) {
    if (pluginGuiX11_)
       pluginGuiX11_->attach(plugin_, nullptr, parentWindow);
 #elif defined(Q_OS_MACX)
-   if (pluginEmbedCocoa_)
+   if (pluginGuiCocoa_)
       pluginGuiCocoa_->attach(plugin_, (void *)parentWindow);
 #elif defined(Q_OS_WIN32)
    if (pluginEmbedWin32_)


### PR DESCRIPTION
A few changes so the host runs on macOS in recent CLion and
so on

1. Bring the CMake needed version back to 3.17
2. Update the README with homebrew packages required
3. Update the host CMakeList to deal with the fact that portmidi
   is not a full package on macOS Homebrew
4. Fix a typon in the host macos code