### PR TITLE
Tweaks for SubModule usage and Mac Debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,13 @@ add_custom_target(clap-compile-tests DEPENDS clap-compile-test-c clap-compile-te
 
 add_subdirectory(examples)
 
+# If you use clap as a submodule of your plugin you need some interface projects
+# to allow you to link. clap-core gives you the include directory and clap-plugin-core
+# gives you the core + plugin-glue.
+add_library(clap-core INTERFACE)
+target_include_directories(clap-core INTERFACE include)
+
+add_library(clap-plugin-core INTERFACE)
+target_link_libraries(clap-plugin-core INTERFACE clap-core clap-plugin-glue)
+
 install(DIRECTORY include DESTINATION "${CMAKE_INSTALL_PREFIX}")

--- a/examples/host/application.cc
+++ b/examples/host/application.cc
@@ -38,6 +38,16 @@ Application::Application(int argc, char **argv)
 
    engine_->setParentWindow(mainWindow_->getEmbedWindowId());
 
+   /*
+    * This is here JUST because macOS and QT don't process command lines properly
+    * and I'm not sure why yet.
+    */
+   if (getenv("CLAP_HOST_FORCE_PLUGIN")) {
+      qWarning() << "Warning: Loading plugin from ENV, not command line";
+      pluginPath_ = getenv("CLAP_HOST_FORCE_PLUGIN");
+      pluginIndex_ = 0;
+   }
+
    if (engine_->loadPlugin(pluginPath_, pluginIndex_))
       engine_->start();
 }

--- a/examples/host/plugin-host.cc
+++ b/examples/host/plugin-host.cc
@@ -110,13 +110,14 @@ bool PluginHost::load(const QString &path, int pluginIndex) {
    library_.setLoadHints(QLibrary::ResolveAllSymbolsHint | QLibrary::DeepBindHint);
    if (!library_.load()) {
       QString err = library_.errorString();
-      qWarning() << "failed to load " << path << ": " << err;
+      qWarning() << "Failed to load plugin '" << path << "': " << err;
       return false;
    }
 
    pluginEntry_ =
       reinterpret_cast<const struct clap_plugin_entry *>(library_.resolve("clap_plugin_entry"));
    if (!pluginEntry_) {
+      qWarning() << "Unable to resolve entry point 'clap_plugin_entry' in '" << path << "'";
       library_.unload();
       return false;
    }


### PR DESCRIPTION
1. Add some interface targets to CMakeLists.txt so
   when clap is used as a submoudle you can add interface
   linkage to your target. Loads more to do here of course

2. Add a better error mesage in one spot in the host

3. On MacOS QT the QTApplication doesn't keep command line
   arguments properly. We should resovle this of course, but for
   now, add an environment variable which overrides the arguments
   to allow me to at least debug my plugin in clion on mac.