### PR TITLE
Add missing dependency on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ brew install qt6
 brew install boost
 brew install portaudio
 brew install portmidi
+brew install pkgconfig
 ```


### PR DESCRIPTION
The CMake process will fail if pkg-config isn't installed. This PR adds the dependency to the macOS build instructions.