### PR TITLE
Fix struct definition for clap_plugin_factory / clap_plugin_factory_t

### DIFF
--- a/include/clap/plugin-factory.h
+++ b/include/clap/plugin-factory.h
@@ -13,7 +13,7 @@ extern "C" {
 
 // Every methods must be thread-safe.
 // It is very important to be able to scan the plugin as quickly as possible.
-struct clap_plugin_factory {
+typedef struct clap_plugin_factory {
    /* Get the number of plugins available.
     * [thread-safe] */
    uint32_t (*get_plugin_count)(const struct clap_plugin_factory *factory);
@@ -33,7 +33,7 @@ struct clap_plugin_factory {
    const clap_plugin_t *(*create_plugin)(const struct clap_plugin_factory *factory,
                                          const clap_host_t                *host,
                                          const char                       *plugin_id);
-};
+} clap_plugin_factory_t;
 
 #pragma pack(pop)
 


### PR DESCRIPTION
This commit fixes the definition to a typedef and defines clap_plugin_factory_t, matching the style of the rest of the SDK.