### PR TITLE
Add nih-plug to the list of community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ and use to get a basic plugin experience:
 - [clap-juce-extension](https://github.com/free-audio/clap-juce-extension), juce add-on
 - [MIP2](https://github.com/skei/MIP2), host and plugins
 - [Avendish](https://github.com/celtera/avendish), a reflection-based API for media plug-ins in C++ which supports Clap
+- [nih-plug](https://github.com/robbert-vdh/nih-plug), an API-agnostic, Rust-based plugin framework aiming to reduce boilerplate without getting in your way
 
 ## Programming Language Bingings
 


### PR DESCRIPTION
Since there's a list of community projects that support CLAP in the readme, I thought it might also be nice to list the little Rust framework I'm working on there since there's not a ton of plugin development in non-C++ languages. The idea of nih-plug is to basically do what JUCE is doing and to make as little assumptions about your plugin as possible, but to also still handle all of the boring repetitive stuff for you that you would need to do by hand in JUCE while also providing abstractions for common use cases beyond the basics. To get an idea for the API you can check out the [examples](https://github.com/robbert-vdh/nih-plug/tree/master/plugins/examples), and there's a more full fledged plugin in the form of a Disperser clone with additional features [here](https://github.com/robbert-vdh/nih-plug/tree/master/plugins/diopser).