### PR TITLE
Allow CLAP_EXPORT to have a custom definition

### DIFF
--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -1,17 +1,19 @@
 #pragma once
 
 // Define CLAP_EXPORT
-#if defined _WIN32 || defined __CYGWIN__
-#   ifdef __GNUC__
-#      define CLAP_EXPORT __attribute__((dllexport))
+#if !defined(CLAP_EXPORT)
+#   if defined _WIN32 || defined __CYGWIN__
+#      ifdef __GNUC__
+#         define CLAP_EXPORT __attribute__((dllexport))
+#      else
+#         define CLAP_EXPORT __declspec(dllexport)
+#      endif
 #   else
-#      define CLAP_EXPORT __declspec(dllexport)
-#   endif
-#else
-#   if __GNUC__ >= 4 || defined(__clang__)
-#      define CLAP_EXPORT __attribute__((visibility("default")))
-#   else
-#      define CLAP_EXPORT
+#      if __GNUC__ >= 4 || defined(__clang__)
+#         define CLAP_EXPORT __attribute__((visibility("default")))
+#      else
+#         define CLAP_EXPORT
+#      endif
 #   endif
 #endif
 


### PR DESCRIPTION
 If building a plugin which is statically wrapped into another format, the symbol `clap_entry` is not desired to be visible.

This patch allows to prevent it by passing `-DCLAP_EXPORT=`.
