### PR TITLE
Add explicit calling conventions to all function pointers

### DIFF
--- a/include/clap/entry.h
+++ b/include/clap/entry.h
@@ -48,16 +48,16 @@ typedef struct clap_plugin_entry {
    //
    // If init() returns false, then the host must not call deinit() nor any other clap
    // related symbols from the DSO.
-   bool (*init)(const char *plugin_path);
+   bool(CLAP_ABI *init)(const char *plugin_path);
 
    // No more calls into the DSO must be made after calling deinit().
-   void (*deinit)(void);
+   void(CLAP_ABI *deinit)(void);
 
    // Get the pointer to a factory. See plugin-factory.h for an example.
    //
    // Returns null if the factory is not provided.
    // The returned pointer must *not* be freed by the caller.
-   const void *(*get_factory)(const char *factory_id);
+   const void *(CLAP_ABI *get_factory)(const char *factory_id);
 } clap_plugin_entry_t;
 
 /* Entry point */

--- a/include/clap/events.h
+++ b/include/clap/events.h
@@ -263,10 +263,10 @@ typedef struct clap_event_midi2 {
 typedef struct clap_input_events {
    void *ctx; // reserved pointer for the list
 
-   uint32_t (*size)(const struct clap_input_events *list);
+   uint32_t(CLAP_ABI *size)(const struct clap_input_events *list);
 
    // Don't free the returned event, it belongs to the list
-   const clap_event_header_t *(*get)(const struct clap_input_events *list, uint32_t index);
+   const clap_event_header_t *(CLAP_ABI *get)(const struct clap_input_events *list, uint32_t index);
 } clap_input_events_t;
 
 // Output event list, events must be sorted by time.
@@ -275,7 +275,8 @@ typedef struct clap_output_events {
 
    // Pushes a copy of the event
    // returns false if the event could not be pushed to the queue (out of memory?)
-   bool (*try_push)(const struct clap_output_events *list, const clap_event_header_t *event);
+   bool(CLAP_ABI *try_push)(const struct clap_output_events *list,
+                            const clap_event_header_t       *event);
 } clap_output_events_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/audio-ports-config.h
+++ b/include/clap/ext/audio-ports-config.h
@@ -50,22 +50,24 @@ typedef struct clap_audio_ports_config {
 typedef struct clap_plugin_audio_ports_config {
    // gets the number of available configurations
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // gets information about a configuration
    // [main-thread]
-   bool (*get)(const clap_plugin_t *plugin, uint32_t index, clap_audio_ports_config_t *config);
+   bool(CLAP_ABI *get)(const clap_plugin_t       *plugin,
+                       uint32_t                   index,
+                       clap_audio_ports_config_t *config);
 
    // selects the configuration designated by id
    // returns true if the configuration could be applied
    // [main-thread,plugin-deactivated]
-   bool (*select)(const clap_plugin_t *plugin, clap_id config_id);
+   bool(CLAP_ABI *select)(const clap_plugin_t *plugin, clap_id config_id);
 } clap_plugin_audio_ports_config_t;
 
 typedef struct clap_host_audio_ports_config {
    // Rescan the full list of configs.
    // [main-thread]
-   void (*rescan)(const clap_host_t *host);
+   void(CLAP_ABI *rescan)(const clap_host_t *host);
 } clap_host_audio_ports_config_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/audio-ports.h
+++ b/include/clap/ext/audio-ports.h
@@ -69,14 +69,14 @@ typedef struct clap_audio_port_info {
 typedef struct clap_plugin_audio_ports {
    // number of ports, for either input or output
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin, bool is_input);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin, bool is_input);
 
    // get info about about an audio port.
    // [main-thread]
-   bool (*get)(const clap_plugin_t    *plugin,
-               uint32_t                index,
-               bool                    is_input,
-               clap_audio_port_info_t *info);
+   bool(CLAP_ABI *get)(const clap_plugin_t    *plugin,
+                       uint32_t                index,
+                       bool                    is_input,
+                       clap_audio_port_info_t *info);
 } clap_plugin_audio_ports_t;
 
 enum {
@@ -102,13 +102,13 @@ enum {
 typedef struct clap_host_audio_ports {
    // Checks if the host allows a plugin to change a given aspect of the audio ports definition.
    // [main-thread]
-   bool (*is_rescan_flag_supported)(const clap_host_t *host, uint32_t flag);
+   bool(CLAP_ABI *is_rescan_flag_supported)(const clap_host_t *host, uint32_t flag);
 
    // Rescan the full list of audio ports according to the flags.
    // It is illegal to ask the host to rescan with a flag that is not supported.
    // Certain flags require the plugin to be de-activated.
    // [main-thread]
-   void (*rescan)(const clap_host_t *host, uint32_t flags);
+   void(CLAP_ABI *rescan)(const clap_host_t *host, uint32_t flags);
 } clap_host_audio_ports_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/ambisonic.h
+++ b/include/clap/ext/draft/ambisonic.h
@@ -36,10 +36,10 @@ typedef struct clap_ambisonic_info {
 typedef struct clap_plugin_ambisonic {
    // Returns true on success
    // [main-thread]
-   bool (*get_info)(const clap_plugin_t   *plugin,
-                    bool                   is_input,
-                    uint32_t               port_index,
-                    clap_ambisonic_info_t *info);
+   bool(CLAP_ABI *get_info)(const clap_plugin_t   *plugin,
+                            bool                   is_input,
+                            uint32_t               port_index,
+                            clap_ambisonic_info_t *info);
 
 } clap_plugin_ambisonic_t;
 
@@ -47,7 +47,7 @@ typedef struct clap_host_ambisonic {
    // Informs the host that the info has changed.
    // The info can only change when the plugin is de-activated.
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_ambisonic_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/check-for-update.h
+++ b/include/clap/ext/draft/check-for-update.h
@@ -18,12 +18,13 @@ typedef struct clap_check_for_update_info {
 
 typedef struct clap_plugin_check_for_update {
    // [main-thread]
-   void (*check)(const clap_plugin_t *plugin, bool include_preview);
+   void(CLAP_ABI *check)(const clap_plugin_t *plugin, bool include_preview);
 } clap_plugin_check_for_update;
 
 typedef struct clap_host_check_for_update {
    // [main-thread]
-   void (*on_new_version)(const clap_host_t *host, const clap_check_for_update_info_t *update_info);
+   void(CLAP_ABI *on_new_version)(const clap_host_t                  *host,
+                                  const clap_check_for_update_info_t *update_info);
 } clap_host_check_for_update_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/cv.h
+++ b/include/clap/ext/draft/cv.h
@@ -25,18 +25,18 @@ enum {
 typedef struct clap_plugin_cv {
    // Returns true on success.
    // [main-thread]
-   bool (*get_channel_type)(const clap_plugin_t *plugin,
-                            bool                 is_input,
-                            uint32_t             port_index,
-                            uint32_t             channel_index,
-                            uint32_t            *channel_type);
+   bool(CLAP_ABI *get_channel_type)(const clap_plugin_t *plugin,
+                                    bool                 is_input,
+                                    uint32_t             port_index,
+                                    uint32_t             channel_index,
+                                    uint32_t            *channel_type);
 } clap_plugin_cv_t;
 
 typedef struct clap_host_cv {
    // Informs the host that the channels type have changed.
    // The channels type can only change when the plugin is de-activated.
    // [main-thread,!active]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_cv_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/file-reference.h
+++ b/include/clap/ext/draft/file-reference.h
@@ -42,12 +42,14 @@ typedef struct clap_file_reference {
 typedef struct clap_plugin_file_reference {
    // returns the number of file reference this plugin has
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // gets the file reference at index
    // returns true on success
    // [main-thread]
-   bool (*get)(const clap_plugin_t *plugin, uint32_t index, clap_file_reference_t *file_reference);
+   bool(CLAP_ABI *get)(const clap_plugin_t   *plugin,
+                       uint32_t               index,
+                       clap_file_reference_t *file_reference);
 
    // This method can be called even if the file is missing.
    // So the plugin is encouraged to store the digest in its state.
@@ -55,29 +57,31 @@ typedef struct clap_plugin_file_reference {
    // digest is an array of 32 bytes.
    //
    // [main-thread]
-   bool (*get_blake3_digest)(const clap_plugin_t *plugin, clap_id resource_id, uint8_t *digest);
+   bool(CLAP_ABI *get_blake3_digest)(const clap_plugin_t *plugin,
+                                     clap_id              resource_id,
+                                     uint8_t             *digest);
 
    // This method can be called even if the file is missing.
    // So the plugin is encouraged to store the file's size in its state.
    //
    // [main-thread]
-   bool (*get_file_size)(const clap_plugin_t *plugin, clap_id resource_id, uint64_t *size);
+   bool(CLAP_ABI *get_file_size)(const clap_plugin_t *plugin, clap_id resource_id, uint64_t *size);
 
    // updates the path to a file reference
    // [main-thread]
-   bool (*update_path)(const clap_plugin_t *plugin, clap_id resource_id, const char *path);
+   bool(CLAP_ABI *update_path)(const clap_plugin_t *plugin, clap_id resource_id, const char *path);
 
    // [main-thread]
-   bool (*save_resources)(const clap_plugin_t *plugin);
+   bool(CLAP_ABI *save_resources)(const clap_plugin_t *plugin);
 } clap_plugin_file_reference_t;
 
 typedef struct clap_host_file_reference {
    // informs the host that the file references have changed, the host should schedule a full rescan
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 
    // [main-thread]
-   void (*set_dirty)(const clap_host_t *host, clap_id resource_id);
+   void(CLAP_ABI *set_dirty)(const clap_host_t *host, clap_id resource_id);
 } clap_host_file_reference;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/midi-mappings.h
+++ b/include/clap/ext/draft/midi-mappings.h
@@ -24,15 +24,15 @@ typedef struct clap_midi_mapping {
 
 typedef struct clap_plugin_midi_mappings {
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // [main-thread]
-   bool (*get)(const clap_plugin_t *plugin, uint32_t index, clap_midi_mapping_t *mapping);
+   bool(CLAP_ABI *get)(const clap_plugin_t *plugin, uint32_t index, clap_midi_mapping_t *mapping);
 } clap_plugin_midi_mappings_t;
 
 typedef struct clap_host_midi_mappings {
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_midi_mappings_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/preset-load.h
+++ b/include/clap/ext/draft/preset-load.h
@@ -11,7 +11,7 @@ extern "C" {
 typedef struct clap_plugin_preset_load {
    // Loads a preset in the plugin native preset file format from a path.
    // [main-thread]
-   bool (*from_file)(const clap_plugin_t *plugin, const char *path);
+   bool(CLAP_ABI *from_file)(const clap_plugin_t *plugin, const char *path);
 } clap_plugin_preset_load_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/quick-controls.h
+++ b/include/clap/ext/draft/quick-controls.h
@@ -23,21 +23,23 @@ typedef struct clap_quick_controls_page {
 
 typedef struct clap_plugin_quick_controls {
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // [main-thread]
-   bool (*get)(const clap_plugin_t *plugin, uint32_t page_index, clap_quick_controls_page_t *page);
+   bool(CLAP_ABI *get)(const clap_plugin_t        *plugin,
+                       uint32_t                    page_index,
+                       clap_quick_controls_page_t *page);
 } clap_plugin_quick_controls_t;
 
 typedef struct clap_host_quick_controls {
    // Informs the host that the quick controls have changed.
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 
    // Suggest a page to the host because it correspond to what the user is currently editing in the
    // plugin's GUI.
    // [main-thread]
-   void (*suggest_page)(const clap_host_t *host, clap_id page_id);
+   void(CLAP_ABI *suggest_page)(const clap_host_t *host, clap_id page_id);
 } clap_host_quick_controls_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/state-context.h
+++ b/include/clap/ext/draft/state-context.h
@@ -44,7 +44,9 @@ typedef struct clap_plugin_state_context {
    // Note that the result may be loaded by both clap_plugin_state.load() and
    // clap_plugin_state_context.load().
    // [main-thread]
-   bool (*save)(const clap_plugin_t *plugin, const clap_ostream_t *stream, uint32_t context_type);
+   bool(CLAP_ABI *save)(const clap_plugin_t  *plugin,
+                        const clap_ostream_t *stream,
+                        uint32_t              context_type);
 
    // Loads the plugin state from stream, according to context_type.
    // Returns true if the state was correctly restored.
@@ -52,7 +54,9 @@ typedef struct clap_plugin_state_context {
    // Note that the state may have been saved by clap_plugin_state.save() or
    // clap_plugin_state_context.save() with a different context_type.
    // [main-thread]
-   bool (*load)(const clap_plugin_t *plugin, const clap_istream_t *stream, uint32_t context_type);
+   bool(CLAP_ABI *load)(const clap_plugin_t  *plugin,
+                        const clap_istream_t *stream,
+                        uint32_t              context_type);
 } clap_plugin_state_context_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/surround.h
+++ b/include/clap/ext/draft/surround.h
@@ -57,29 +57,29 @@ typedef struct clap_plugin_surround {
    // Stores into the channel_map array, the surround identifer of each channels.
    // Returns the number of elements stored in channel_map
    // [main-thread]
-   uint32_t (*get_channel_map)(const clap_plugin_t *plugin,
-                               bool                 is_input,
-                               uint32_t             port_index,
-                               uint8_t             *channel_map,
-                               uint32_t             channel_map_capacity);
+   uint32_t(CLAP_ABI *get_channel_map)(const clap_plugin_t *plugin,
+                                       bool                 is_input,
+                                       uint32_t             port_index,
+                                       uint8_t             *channel_map,
+                                       uint32_t             channel_map_capacity);
 
    // Informs the plugin that the host preferred channel map has changed.
    // [main-thread]
-   void (*changed)(const clap_plugin_t *plugin);
+   void(CLAP_ABI *changed)(const clap_plugin_t *plugin);
 } clap_plugin_surround_t;
 
 typedef struct clap_host_surround {
    // Informs the host that the channel map has changed.
    // The channel map can only change when the plugin is de-activated.
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 
    // Ask the host what is the prefered/project surround channel map.
    // [main-thread]
-   void (*get_preferred_channel_map)(const clap_host_t *host,
-                                     uint8_t           *channel_map,
-                                     uint32_t           channel_map_capacity,
-                                     uint32_t          *channel_count);
+   void(CLAP_ABI *get_preferred_channel_map)(const clap_host_t *host,
+                                             uint8_t           *channel_map,
+                                             uint32_t           channel_map_capacity,
+                                             uint32_t          *channel_count);
 } clap_host_surround_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/track-info.h
+++ b/include/clap/ext/draft/track-info.h
@@ -23,13 +23,13 @@ typedef struct clap_track_info {
 
 typedef struct clap_plugin_track_info {
    // [main-thread]
-   void (*changed)(const clap_plugin_t *plugin);
+   void(CLAP_ABI *changed)(const clap_plugin_t *plugin);
 } clap_plugin_track_info_t;
 
 typedef struct clap_host_track_info {
    // Get info about the track the plugin belongs to.
    // [main-thread]
-   bool (*get)(const clap_host_t *host, clap_track_info_t *info);
+   bool(CLAP_ABI *get)(const clap_host_t *host, clap_track_info_t *info);
 } clap_host_track_info_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/transport-control.h
+++ b/include/clap/ext/draft/transport-control.h
@@ -15,48 +15,50 @@ extern "C" {
 typedef struct clap_host_transport_control {
    // Jumps back to the start point and starts the transport
    // [main-thread]
-   void (*request_start)(const clap_host_t *host);
+   void(CLAP_ABI *request_start)(const clap_host_t *host);
 
    // Stops the transport, and jumps to the start point
    // [main-thread]
-   void (*request_stop)(const clap_host_t *host);
+   void(CLAP_ABI *request_stop)(const clap_host_t *host);
 
    // If not playing, starts the transport from its current position
    // [main-thread]
-   void (*request_continue)(const clap_host_t *host);
+   void(CLAP_ABI *request_continue)(const clap_host_t *host);
 
    // If playing, stops the transport at the current position
    // [main-thread]
-   void (*request_pause)(const clap_host_t *host);
+   void(CLAP_ABI *request_pause)(const clap_host_t *host);
 
    // Equivalent to what "space bar" does with most DAWs
    // [main-thread]
-   void (*request_toggle_play)(const clap_host_t *host);
+   void(CLAP_ABI *request_toggle_play)(const clap_host_t *host);
 
    // Jumps the transport to the given position.
    // Does not start the transport.
    // [main-thread]
-   void (*request_jump)(const clap_host_t *host, clap_beattime position);
+   void(CLAP_ABI *request_jump)(const clap_host_t *host, clap_beattime position);
 
    // Sets the loop region
    // [main-thread]
-   void (*request_loop_region)(const clap_host_t *host, clap_beattime start, clap_beattime duration);
+   void(CLAP_ABI *request_loop_region)(const clap_host_t *host,
+                                       clap_beattime      start,
+                                       clap_beattime      duration);
 
    // Toggles looping
    // [main-thread]
-   void (*request_toggle_loop)(const clap_host_t *host);
+   void(CLAP_ABI *request_toggle_loop)(const clap_host_t *host);
 
    // Enables/Disables looping
    // [main-thread]
-   void (*request_enable_loop)(const clap_host_t *host, bool is_enabled);
+   void(CLAP_ABI *request_enable_loop)(const clap_host_t *host, bool is_enabled);
 
    // Enables/Disables recording
    // [main-thread]
-   void (*request_record)(const clap_host_t *host, bool is_recording);
+   void(CLAP_ABI *request_record)(const clap_host_t *host, bool is_recording);
 
    // Toggles recording
    // [main-thread]
-   void (*request_toggle_record)(const clap_host_t *host);
+   void(CLAP_ABI *request_toggle_record)(const clap_host_t *host);
 } clap_host_transport_control_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/tuning.h
+++ b/include/clap/ext/draft/tuning.h
@@ -30,7 +30,7 @@ typedef struct clap_tuning_info {
 typedef struct clap_plugin_tuning {
    // Called when a tuning is added or removed from the pool.
    // [main-thread]
-   void (*changed)(const clap_plugin_t *plugin);
+   void(CLAP_ABI *changed)(const clap_plugin_t *plugin);
 } clap_plugin_tuning_t;
 
 // This extension provides a dynamic tuning table to the plugin.
@@ -46,23 +46,28 @@ typedef struct clap_host_tuning {
    // should_play(...) should be checked before calling this function.
    //
    // [audio-thread & in-process]
-   double (*get_relative)(const clap_host_t *host,
-                          clap_id            tuning_id,
-                          int32_t            channel,
-                          int32_t            key,
-                          uint32_t           sample_offset);
+   double(CLAP_ABI *get_relative)(const clap_host_t *host,
+                                  clap_id            tuning_id,
+                                  int32_t            channel,
+                                  int32_t            key,
+                                  uint32_t           sample_offset);
 
    // Returns true if the note should be played.
    // [audio-thread & in-process]
-   bool (*should_play)(const clap_host_t *host, clap_id tuning_id, int32_t channel, int32_t key);
+   bool(CLAP_ABI *should_play)(const clap_host_t *host,
+                               clap_id            tuning_id,
+                               int32_t            channel,
+                               int32_t            key);
 
    // Returns the number of tunings in the pool.
    // [main-thread]
-   uint32_t (*get_tuning_count)(const clap_host_t *host);
+   uint32_t(CLAP_ABI *get_tuning_count)(const clap_host_t *host);
 
    // Gets info about a tuning
    // [main-thread]
-   bool (*get_info)(const clap_host_t *host, uint32_t tuning_index, clap_tuning_info_t *info);
+   bool(CLAP_ABI *get_info)(const clap_host_t  *host,
+                            uint32_t            tuning_index,
+                            clap_tuning_info_t *info);
 } clap_host_tuning_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/event-registry.h
+++ b/include/clap/ext/event-registry.h
@@ -14,7 +14,7 @@ typedef struct clap_host_event_registry {
    //
    // Return false and sets *space to UINT16_MAX if the space name is unknown to the host.
    // [main-thread]
-   bool (*query)(const clap_host_t *host, const char *space_name, uint16_t *space_id);
+   bool(CLAP_ABI *query)(const clap_host_t *host, const char *space_name, uint16_t *space_id);
 } clap_host_event_registry_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/gui.h
+++ b/include/clap/ext/gui.h
@@ -96,14 +96,16 @@ typedef struct clap_gui_resize_hints {
 typedef struct clap_plugin_gui {
    // Returns true if the requested gui api is supported
    // [main-thread]
-   bool (*is_api_supported)(const clap_plugin_t *plugin, const char *api, bool is_floating);
+   bool(CLAP_ABI *is_api_supported)(const clap_plugin_t *plugin, const char *api, bool is_floating);
 
    // Returns true if the plugin has a preferred api.
    // The host has no obligation to honor the plugin preferrence, this is just a hint.
    // The const char **api variable should be explicitly assigned as a pointer to
    // one of the CLAP_WINDOW_API_ constants defined above, not strcopied.
    // [main-thread]
-   bool (*get_preferred_api)(const clap_plugin_t *plugin, const char **api, bool *is_floating);
+   bool(CLAP_ABI *get_preferred_api)(const clap_plugin_t *plugin,
+                                     const char         **api,
+                                     bool                *is_floating);
 
    // Create and allocate all resources necessary for the gui.
    //
@@ -116,11 +118,11 @@ typedef struct clap_plugin_gui {
    //
    // After this call, the GUI may not be visible yet; don't forget to call show().
    // [main-thread]
-   bool (*create)(const clap_plugin_t *plugin, const char *api, bool is_floating);
+   bool(CLAP_ABI *create)(const clap_plugin_t *plugin, const char *api, bool is_floating);
 
    // Free all resources associated with the gui.
    // [main-thread]
-   void (*destroy)(const clap_plugin_t *plugin);
+   void(CLAP_ABI *destroy)(const clap_plugin_t *plugin);
 
    // Set the absolute GUI scaling factor, and override any OS info.
    // Should not be used if the windowing api relies upon logical pixels.
@@ -131,21 +133,21 @@ typedef struct clap_plugin_gui {
    // Returns true if the scaling could be applied
    // Returns false if the call was ignored, or the scaling could not be applied.
    // [main-thread]
-   bool (*set_scale)(const clap_plugin_t *plugin, double scale);
+   bool(CLAP_ABI *set_scale)(const clap_plugin_t *plugin, double scale);
 
    // Get the current size of the plugin UI.
    // clap_plugin_gui->create() must have been called prior to asking the size.
    // [main-thread]
-   bool (*get_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
+   bool(CLAP_ABI *get_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
 
    // Returns true if the window is resizeable (mouse drag).
    // Only for embedded windows.
    // [main-thread]
-   bool (*can_resize)(const clap_plugin_t *plugin);
+   bool(CLAP_ABI *can_resize)(const clap_plugin_t *plugin);
 
    // Returns true if the plugin can provide hints on how to resize the window.
    // [main-thread]
-   bool (*get_resize_hints)(const clap_plugin_t *plugin, clap_gui_resize_hints_t *hints);
+   bool(CLAP_ABI *get_resize_hints)(const clap_plugin_t *plugin, clap_gui_resize_hints_t *hints);
 
    // If the plugin gui is resizable, then the plugin will calculate the closest
    // usable size which fits in the given size.
@@ -153,38 +155,38 @@ typedef struct clap_plugin_gui {
    //
    // Only for embedded windows.
    // [main-thread]
-   bool (*adjust_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
+   bool(CLAP_ABI *adjust_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
 
    // Sets the window size. Only for embedded windows.
    // [main-thread]
-   bool (*set_size)(const clap_plugin_t *plugin, uint32_t width, uint32_t height);
+   bool(CLAP_ABI *set_size)(const clap_plugin_t *plugin, uint32_t width, uint32_t height);
 
    // Embbeds the plugin window into the given window.
    // [main-thread & !floating]
-   bool (*set_parent)(const clap_plugin_t *plugin, const clap_window_t *window);
+   bool(CLAP_ABI *set_parent)(const clap_plugin_t *plugin, const clap_window_t *window);
 
    // Set the plugin floating window to stay above the given window.
    // [main-thread & floating]
-   bool (*set_transient)(const clap_plugin_t *plugin, const clap_window_t *window);
+   bool(CLAP_ABI *set_transient)(const clap_plugin_t *plugin, const clap_window_t *window);
 
    // Suggests a window title. Only for floating windows.
    // [main-thread & floating]
-   void (*suggest_title)(const clap_plugin_t *plugin, const char *title);
+   void(CLAP_ABI *suggest_title)(const clap_plugin_t *plugin, const char *title);
 
    // Show the window.
    // [main-thread]
-   bool (*show)(const clap_plugin_t *plugin);
+   bool(CLAP_ABI *show)(const clap_plugin_t *plugin);
 
    // Hide the window, this method does not free the resources, it just hides
    // the window content. Yet it may be a good idea to stop painting timers.
    // [main-thread]
-   bool (*hide)(const clap_plugin_t *plugin);
+   bool(CLAP_ABI *hide)(const clap_plugin_t *plugin);
 } clap_plugin_gui_t;
 
 typedef struct clap_host_gui {
    // The host should call get_resize_hints() again.
    // [thread-safe]
-   void (*resize_hints_changed)(const clap_host_t *host);
+   void(CLAP_ABI *resize_hints_changed)(const clap_host_t *host);
 
    /* Request the host to resize the client area to width, height.
     * Return true if the new size is accepted, false otherwise.
@@ -195,24 +197,24 @@ typedef struct clap_host_gui {
     * satisfied then the host will call set_size() to revert the operation.
     *
     * [thread-safe] */
-   bool (*request_resize)(const clap_host_t *host, uint32_t width, uint32_t height);
+   bool(CLAP_ABI *request_resize)(const clap_host_t *host, uint32_t width, uint32_t height);
 
    /* Request the host to show the plugin gui.
     * Return true on success, false otherwise.
     * [thread-safe] */
-   bool (*request_show)(const clap_host_t *host);
+   bool(CLAP_ABI *request_show)(const clap_host_t *host);
 
    /* Request the host to hide the plugin gui.
     * Return true on success, false otherwise.
     * [thread-safe] */
-   bool (*request_hide)(const clap_host_t *host);
+   bool(CLAP_ABI *request_hide)(const clap_host_t *host);
 
    // The floating window has been closed, or the connection to the gui has been lost.
    //
    // If was_destroyed is true, then the host must call clap_plugin_gui->destroy() to acknowledge
    // the gui destruction.
    // [thread-safe]
-   void (*closed)(const clap_host_t *host, bool was_destroyed);
+   void(CLAP_ABI *closed)(const clap_host_t *host, bool was_destroyed);
 } clap_host_gui_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/latency.h
+++ b/include/clap/ext/latency.h
@@ -12,7 +12,7 @@ extern "C" {
 typedef struct clap_plugin_latency {
    // Returns the plugin latency.
    // [main-thread]
-   uint32_t (*get)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *get)(const clap_plugin_t *plugin);
 } clap_plugin_latency_t;
 
 typedef struct clap_host_latency {
@@ -20,7 +20,7 @@ typedef struct clap_host_latency {
    // The latency is only allowed to change if the plugin is deactivated.
    // If the plugin is activated, call host->request_restart()
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_latency_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/log.h
+++ b/include/clap/ext/log.h
@@ -25,7 +25,7 @@ typedef int32_t clap_log_severity;
 typedef struct clap_host_log {
    // Log a message through the host.
    // [thread-safe]
-   void (*log)(const clap_host_t *host, clap_log_severity severity, const char *msg);
+   void(CLAP_ABI *log)(const clap_host_t *host, clap_log_severity severity, const char *msg);
 } clap_host_log_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/note-name.h
+++ b/include/clap/ext/note-name.h
@@ -19,17 +19,17 @@ typedef struct clap_note_name {
 typedef struct clap_plugin_note_name {
    // Return the number of note names
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // Returns true on success and stores the result into note_name
    // [main-thread]
-   bool (*get)(const clap_plugin_t *plugin, uint32_t index, clap_note_name_t *note_name);
+   bool(CLAP_ABI *get)(const clap_plugin_t *plugin, uint32_t index, clap_note_name_t *note_name);
 } clap_plugin_note_name_t;
 
 typedef struct clap_host_note_name {
    // Informs the host that the note names have changed.
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_note_name_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/note-ports.h
+++ b/include/clap/ext/note-ports.h
@@ -42,14 +42,14 @@ typedef struct clap_note_port_info {
 typedef struct clap_plugin_note_ports {
    // number of ports, for either input or output
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin, bool is_input);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin, bool is_input);
 
    // get info about about a note port.
    // [main-thread]
-   bool (*get)(const clap_plugin_t   *plugin,
-               uint32_t               index,
-               bool                   is_input,
-               clap_note_port_info_t *info);
+   bool(CLAP_ABI *get)(const clap_plugin_t   *plugin,
+                       uint32_t               index,
+                       bool                   is_input,
+                       clap_note_port_info_t *info);
 } clap_plugin_note_ports_t;
 
 enum {
@@ -66,11 +66,11 @@ enum {
 typedef struct clap_host_note_ports {
    // Query which dialects the host supports
    // [main-thread]
-   uint32_t (*supported_dialects)(const clap_host_t *host);
+   uint32_t(CLAP_ABI *supported_dialects)(const clap_host_t *host);
 
    // Rescan the full list of note ports according to the flags.
    // [main-thread]
-   void (*rescan)(const clap_host_t *host, uint32_t flags);
+   void(CLAP_ABI *rescan)(const clap_host_t *host, uint32_t flags);
 } clap_host_note_ports_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -183,39 +183,39 @@ typedef struct clap_param_info {
 typedef struct clap_plugin_params {
    // Returns the number of parameters.
    // [main-thread]
-   uint32_t (*count)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *count)(const clap_plugin_t *plugin);
 
    // Copies the parameter's info to param_info and returns true on success.
    // [main-thread]
-   bool (*get_info)(const clap_plugin_t *plugin,
-                    uint32_t             param_index,
-                    clap_param_info_t   *param_info);
+   bool(CLAP_ABI *get_info)(const clap_plugin_t *plugin,
+                            uint32_t             param_index,
+                            clap_param_info_t   *param_info);
 
    // Gets the parameter plain value.
    // [main-thread]
-   bool (*get_value)(const clap_plugin_t *plugin, clap_id param_id, double *value);
+   bool(CLAP_ABI *get_value)(const clap_plugin_t *plugin, clap_id param_id, double *value);
 
    // Formats the display text for the given parameter value.
    // The host should always format the parameter value to text using this function
    // before displaying it to the user.
    // [main-thread]
-   bool (*value_to_text)(
+   bool(CLAP_ABI *value_to_text)(
       const clap_plugin_t *plugin, clap_id param_id, double value, char *display, uint32_t size);
 
    // Converts the display text to a parameter value.
    // [main-thread]
-   bool (*text_to_value)(const clap_plugin_t *plugin,
-                         clap_id              param_id,
-                         const char          *display,
-                         double              *value);
+   bool(CLAP_ABI *text_to_value)(const clap_plugin_t *plugin,
+                                 clap_id              param_id,
+                                 const char          *display,
+                                 double              *value);
 
    // Flushes a set of parameter changes.
    // This method must not be called concurrently to clap_plugin->process().
    //
    // [active ? audio-thread : main-thread]
-   void (*flush)(const clap_plugin_t        *plugin,
-                 const clap_input_events_t  *in,
-                 const clap_output_events_t *out);
+   void(CLAP_ABI *flush)(const clap_plugin_t        *plugin,
+                         const clap_input_events_t  *in,
+                         const clap_output_events_t *out);
 } clap_plugin_params_t;
 
 enum {
@@ -272,11 +272,11 @@ typedef uint32_t clap_param_clear_flags;
 typedef struct clap_host_params {
    // Rescan the full list of parameters according to the flags.
    // [main-thread]
-   void (*rescan)(const clap_host_t *host, clap_param_rescan_flags flags);
+   void(CLAP_ABI *rescan)(const clap_host_t *host, clap_param_rescan_flags flags);
 
    // Clears references to a parameter.
    // [main-thread]
-   void (*clear)(const clap_host_t *host, clap_id param_id, clap_param_clear_flags flags);
+   void(CLAP_ABI *clear)(const clap_host_t *host, clap_id param_id, clap_param_clear_flags flags);
 
    // Request a parameter flush.
    //
@@ -288,7 +288,7 @@ typedef struct clap_host_params {
    // plugin would already be within process() or flush().
    //
    // [thread-safe,!audio-thread]
-   void (*request_flush)(const clap_host_t *host);
+   void(CLAP_ABI *request_flush)(const clap_host_t *host);
 } clap_host_params_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/posix-fd-support.h
+++ b/include/clap/ext/posix-fd-support.h
@@ -27,18 +27,18 @@ typedef struct clap_plugin_posix_fd_support {
    // done writting.
    //
    // [main-thread]
-   void (*on_fd)(const clap_plugin_t *plugin, int fd, clap_posix_fd_flags_t flags);
+   void(CLAP_ABI *on_fd)(const clap_plugin_t *plugin, int fd, clap_posix_fd_flags_t flags);
 } clap_plugin_posix_fd_support_t;
 
 typedef struct clap_host_posix_fd_support {
    // [main-thread]
-   bool (*register_fd)(const clap_host_t *host, int fd, clap_posix_fd_flags_t flags);
+   bool(CLAP_ABI *register_fd)(const clap_host_t *host, int fd, clap_posix_fd_flags_t flags);
 
    // [main-thread]
-   bool (*modify_fd)(const clap_host_t *host, int fd, clap_posix_fd_flags_t flags);
+   bool(CLAP_ABI *modify_fd)(const clap_host_t *host, int fd, clap_posix_fd_flags_t flags);
 
    // [main-thread]
-   bool (*unregister_fd)(const clap_host_t *host, int fd);
+   bool(CLAP_ABI *unregister_fd)(const clap_host_t *host, int fd);
 } clap_host_posix_fd_support_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/render.h
+++ b/include/clap/ext/render.h
@@ -27,11 +27,11 @@ typedef struct clap_plugin_render {
    // Returns true if the plugin has an hard requirement to process in real-time.
    // This is especially useful for plugin acting as a proxy to an hardware device.
    // [main-thread]
-   bool (*has_hard_realtime_requirement)(const clap_plugin_t *plugin);
+   bool(CLAP_ABI *has_hard_realtime_requirement)(const clap_plugin_t *plugin);
 
    // Returns true if the rendering mode could be applied.
    // [main-thread]
-   bool (*set)(const clap_plugin_t *plugin, clap_plugin_render_mode mode);
+   bool(CLAP_ABI *set)(const clap_plugin_t *plugin, clap_plugin_render_mode mode);
 } clap_plugin_render_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/state.h
+++ b/include/clap/ext/state.h
@@ -13,19 +13,19 @@ typedef struct clap_plugin_state {
    // Saves the plugin state into stream.
    // Returns true if the state was correctly saved.
    // [main-thread]
-   bool (*save)(const clap_plugin_t *plugin, const clap_ostream_t *stream);
+   bool(CLAP_ABI *save)(const clap_plugin_t *plugin, const clap_ostream_t *stream);
 
    // Loads the plugin state from stream.
    // Returns true if the state was correctly restored.
    // [main-thread]
-   bool (*load)(const clap_plugin_t *plugin, const clap_istream_t *stream);
+   bool(CLAP_ABI *load)(const clap_plugin_t *plugin, const clap_istream_t *stream);
 } clap_plugin_state_t;
 
 typedef struct clap_host_state {
    // Tell the host that the plugin state has changed and should be saved again.
    // If a parameter value changes, then it is implicit that the state is dirty.
    // [main-thread]
-   void (*mark_dirty)(const clap_host_t *host);
+   void(CLAP_ABI *mark_dirty)(const clap_host_t *host);
 } clap_host_state_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/tail.h
+++ b/include/clap/ext/tail.h
@@ -12,13 +12,13 @@ typedef struct clap_plugin_tail {
    // Returns tail length in samples.
    // Any value greater or equal to INT32_MAX implies infinite tail.
    // [main-thread,audio-thread]
-   uint32_t (*get)(const clap_plugin_t *plugin);
+   uint32_t(CLAP_ABI *get)(const clap_plugin_t *plugin);
 } clap_plugin_tail_t;
 
 typedef struct clap_host_tail {
    // Tell the host that the tail has changed.
    // [audio-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_tail_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -39,11 +39,11 @@ extern "C" {
 typedef struct clap_host_thread_check {
    // Returns true if "this" thread is the main thread.
    // [thread-safe]
-   bool (*is_main_thread)(const clap_host_t *host);
+   bool(CLAP_ABI *is_main_thread)(const clap_host_t *host);
 
    // Returns true if "this" thread is one of the audio threads.
    // [thread-safe]
-   bool (*is_audio_thread)(const clap_host_t *host);
+   bool(CLAP_ABI *is_audio_thread)(const clap_host_t *host);
 } clap_host_thread_check_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/thread-pool.h
+++ b/include/clap/ext/thread-pool.h
@@ -46,7 +46,7 @@ extern "C" {
 
 typedef struct clap_plugin_thread_pool {
    // Called by the thread pool
-   void (*exec)(const clap_plugin_t *plugin, uint32_t task_index);
+   void(CLAP_ABI *exec)(const clap_plugin_t *plugin, uint32_t task_index);
 } clap_plugin_thread_pool_t;
 
 typedef struct clap_host_thread_pool {
@@ -58,7 +58,7 @@ typedef struct clap_host_thread_pool {
    // The host should check that the plugin is within the process call, and if not, reject the exec
    // request.
    // [audio-thread]
-   bool (*request_exec)(const clap_host_t *host, uint32_t num_tasks);
+   bool(CLAP_ABI *request_exec)(const clap_host_t *host, uint32_t num_tasks);
 } clap_host_thread_pool_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/timer-support.h
+++ b/include/clap/ext/timer-support.h
@@ -10,7 +10,7 @@ extern "C" {
 
 typedef struct clap_plugin_timer_support {
    // [main-thread]
-   void (*on_timer)(const clap_plugin_t *plugin, clap_id timer_id);
+   void(CLAP_ABI *on_timer)(const clap_plugin_t *plugin, clap_id timer_id);
 } clap_plugin_timer_support_t;
 
 typedef struct clap_host_timer_support {
@@ -18,10 +18,10 @@ typedef struct clap_host_timer_support {
    // The host may adjust the period if it is under a certain threshold.
    // 30 Hz should be allowed.
    // [main-thread]
-   bool (*register_timer)(const clap_host_t *host, uint32_t period_ms, clap_id *timer_id);
+   bool(CLAP_ABI *register_timer)(const clap_host_t *host, uint32_t period_ms, clap_id *timer_id);
 
    // [main-thread]
-   bool (*unregister_timer)(const clap_host_t *host, clap_id timer_id);
+   bool(CLAP_ABI *unregister_timer)(const clap_host_t *host, clap_id timer_id);
 } clap_host_timer_support_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/voice-info.h
+++ b/include/clap/ext/voice-info.h
@@ -42,13 +42,13 @@ typedef struct clap_voice_info {
 typedef struct clap_plugin_voice_info {
    // gets the voice info, returns true on success
    // [main-thread && active]
-   bool (*get)(const clap_plugin_t *plugin, clap_voice_info_t *info);
+   bool(CLAP_ABI *get)(const clap_plugin_t *plugin, clap_voice_info_t *info);
 } clap_plugin_voice_info_t;
 
 typedef struct clap_host_voice_info {
    // informs the host that the voice info has changed
    // [main-thread]
-   void (*changed)(const clap_host_t *host);
+   void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_voice_info_t;
 
 #ifdef __cplusplus

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -19,21 +19,21 @@ typedef struct clap_host {
 
    // Query an extension.
    // [thread-safe]
-   const void *(*get_extension)(const struct clap_host *host, const char *extension_id);
+   const void *(CLAP_ABI *get_extension)(const struct clap_host *host, const char *extension_id);
 
    // Request the host to deactivate and then reactivate the plugin.
    // The operation may be delayed by the host.
    // [thread-safe]
-   void (*request_restart)(const struct clap_host *host);
+   void(CLAP_ABI *request_restart)(const struct clap_host *host);
 
    // Request the host to activate and start processing the plugin.
    // This is useful if you have external IO and need to wake up the plugin from "sleep".
    // [thread-safe]
-   void (*request_process)(const struct clap_host *host);
+   void(CLAP_ABI *request_process)(const struct clap_host *host);
 
    // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
    // [thread-safe]
-   void (*request_callback)(const struct clap_host *host);
+   void(CLAP_ABI *request_callback)(const struct clap_host *host);
 } clap_host_t;
 
 #ifdef __cplusplus

--- a/include/clap/plugin-factory.h
+++ b/include/clap/plugin-factory.h
@@ -15,13 +15,13 @@ extern "C" {
 typedef struct clap_plugin_factory {
    // Get the number of plugins available.
    // [thread-safe]
-   uint32_t (*get_plugin_count)(const struct clap_plugin_factory *factory);
+   uint32_t(CLAP_ABI *get_plugin_count)(const struct clap_plugin_factory *factory);
 
    // Retrieves a plugin descriptor by its index.
    // Returns null in case of error.
    // The descriptor must not be freed.
    // [thread-safe]
-   const clap_plugin_descriptor_t *(*get_plugin_descriptor)(
+   const clap_plugin_descriptor_t *(CLAP_ABI *get_plugin_descriptor)(
       const struct clap_plugin_factory *factory, uint32_t index);
 
    // Create a clap_plugin by its plugin_id.
@@ -29,9 +29,9 @@ typedef struct clap_plugin_factory {
    // The plugin is not allowed to use the host callbacks in the create method.
    // Returns null in case of error.
    // [thread-safe]
-   const clap_plugin_t *(*create_plugin)(const struct clap_plugin_factory *factory,
-                                         const clap_host_t                *host,
-                                         const char                       *plugin_id);
+   const clap_plugin_t *(CLAP_ABI *create_plugin)(const struct clap_plugin_factory *factory,
+                                                  const clap_host_t                *host,
+                                                  const char                       *plugin_id);
 } clap_plugin_factory_t;
 
 #ifdef __cplusplus

--- a/include/clap/plugin-invalidation.h
+++ b/include/clap/plugin-invalidation.h
@@ -27,17 +27,17 @@ static const CLAP_CONSTEXPR char CLAP_PLUGIN_INVALIDATION_FACTORY_ID[] =
 // This interfaces solves this issue and gives a way to the host to monitor additional files.
 typedef struct clap_plugin_invalidation_factory {
    // Get the number of invalidation source.
-   uint32_t (*count)(const struct clap_plugin_invalidation_factory *factory);
+   uint32_t(CLAP_ABI *count)(const struct clap_plugin_invalidation_factory *factory);
 
    // Get the invalidation source by its index.
    // [thread-safe]
-   const clap_plugin_invalidation_source_t *(*get)(
+   const clap_plugin_invalidation_source_t *(CLAP_ABI *get)(
       const struct clap_plugin_invalidation_factory *factory, uint32_t index);
 
    // In case the host detected a invalidation event, it can call refresh() to let the
    // plugin_entry update the set of plugins available.
    // If the function returned false, then the plugin needs to be reloaded.
-   bool (*refresh)(const struct clap_plugin_invalidation_factory *factory);
+   bool(CLAP_ABI *refresh)(const struct clap_plugin_invalidation_factory *factory);
 } clap_plugin_invalidation_factory_t;
 
 #ifdef __cplusplus

--- a/include/clap/plugin.h
+++ b/include/clap/plugin.h
@@ -38,12 +38,12 @@ typedef struct clap_plugin {
    // Must be called after creating the plugin.
    // If init returns false, the host must destroy the plugin instance.
    // [main-thread]
-   bool (*init)(const struct clap_plugin *plugin);
+   bool(CLAP_ABI *init)(const struct clap_plugin *plugin);
 
    // Free the plugin and its resources.
    // It is required to deactivate the plugin prior to this call.
    // [main-thread & !active]
-   void (*destroy)(const struct clap_plugin *plugin);
+   void(CLAP_ABI *destroy)(const struct clap_plugin *plugin);
 
    // Activate and deactivate the plugin.
    // In this call the plugin may allocate memory and prepare everything needed for the process
@@ -52,20 +52,20 @@ typedef struct clap_plugin {
    // Once activated the latency and port configuration must remain constant, until deactivation.
    //
    // [main-thread & !active_state]
-   bool (*activate)(const struct clap_plugin *plugin,
-                    double                    sample_rate,
-                    uint32_t                  min_frames_count,
-                    uint32_t                  max_frames_count);
+   bool(CLAP_ABI *activate)(const struct clap_plugin *plugin,
+                            double                    sample_rate,
+                            uint32_t                  min_frames_count,
+                            uint32_t                  max_frames_count);
    // [main-thread & active_state]
-   void (*deactivate)(const struct clap_plugin *plugin);
+   void(CLAP_ABI *deactivate)(const struct clap_plugin *plugin);
 
    // Call start processing before processing.
    // [audio-thread & active_state & !processing_state]
-   bool (*start_processing)(const struct clap_plugin *plugin);
+   bool(CLAP_ABI *start_processing)(const struct clap_plugin *plugin);
 
    // Call stop processing before sending the plugin to sleep.
    // [audio-thread & active_state & processing_state]
-   void (*stop_processing)(const struct clap_plugin *plugin);
+   void(CLAP_ABI *stop_processing)(const struct clap_plugin *plugin);
 
    // - Clears all buffers, performs a full reset of the processing state (filters, oscillators,
    //   enveloppes, lfo, ...) and kills all voices.
@@ -73,21 +73,22 @@ typedef struct clap_plugin {
    // - clap_process.steady_time may jump backward.
    //
    // [audio-thread & active_state]
-   void (*reset)(const struct clap_plugin *plugin);
+   void(CLAP_ABI *reset)(const struct clap_plugin *plugin);
 
    // process audio, events, ...
    // [audio-thread & active_state & processing_state]
-   clap_process_status (*process)(const struct clap_plugin *plugin, const clap_process_t *process);
+   clap_process_status(CLAP_ABI *process)(const struct clap_plugin *plugin,
+                                          const clap_process_t     *process);
 
    // Query an extension.
    // The returned pointer is owned by the plugin.
    // [thread-safe]
-   const void *(*get_extension)(const struct clap_plugin *plugin, const char *id);
+   const void *(CLAP_ABI *get_extension)(const struct clap_plugin *plugin, const char *id);
 
    // Called by the host on the main thread in response to a previous call to:
    //   host->request_callback(host);
    // [main-thread]
-   void (*on_main_thread)(const struct clap_plugin *plugin);
+   void(CLAP_ABI *on_main_thread)(const struct clap_plugin *plugin);
 } clap_plugin_t;
 
 #ifdef __cplusplus

--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -17,6 +17,14 @@
 #   endif
 #endif
 
+#if !defined(CLAP_ABI)
+#   if defined _WIN32 || defined __CYGWIN__
+#      define CLAP_ABI __cdecl
+#   else
+#      define CLAP_ABI
+#   endif
+#endif
+
 #if defined(__cplusplus) && __cplusplus >= 201103L
 #   define CLAP_HAS_CXX11
 #   define CLAP_CONSTEXPR constexpr

--- a/include/clap/stream.h
+++ b/include/clap/stream.h
@@ -11,14 +11,14 @@ typedef struct clap_istream {
    void *ctx; // reserved pointer for the stream
 
    // returns the number of bytes read; 0 indicates end of file and -1 a read error
-   int64_t (*read)(const struct clap_istream *stream, void *buffer, uint64_t size);
+   int64_t(CLAP_ABI *read)(const struct clap_istream *stream, void *buffer, uint64_t size);
 } clap_istream_t;
 
 typedef struct clap_ostream {
    void *ctx; // reserved pointer for the stream
 
    // returns the number of bytes written; -1 on write error
-   int64_t (*write)(const struct clap_ostream *stream, const void *buffer, uint64_t size);
+   int64_t(CLAP_ABI *write)(const struct clap_ostream *stream, const void *buffer, uint64_t size);
 } clap_ostream_t;
 
 #ifdef __cplusplus

--- a/src/plugin-template.c
+++ b/src/plugin-template.c
@@ -287,7 +287,7 @@ clap_plugin_t *my_plug_create(const clap_host_t *host) {
 
 static struct {
    const clap_plugin_descriptor_t *desc;
-   clap_plugin_t *(*create)(const clap_host_t *host);
+   clap_plugin_t *(CLAP_ABI *create)(const clap_host_t *host);
 } s_plugins[] = {
    {
       .desc = &s_my_plug_desc,


### PR DESCRIPTION
This addresses the problem described in #153. Without this systems with multiple calling conventions (like x86 Windows, or a future platform) may not use the correct calling convention when calling these functions. And even if the correct calling convention is used, calling these functions would still be undefined behavior as the default calling convention depends on the compiler. It's also required for being able to use CLAP in a [Winelib](https://wiki.winehq.org/Winelib) setup, as the `__cdecl` calling convention tells GCC to use the Microsoft x64 ABI for those functions.