### PR TITLE
Clarify that input buffer is read-only

### DIFF
--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -47,6 +47,7 @@ typedef struct clap_process {
    // Audio buffers, they must have the same count as specified
    // by clap_plugin_audio_ports->get_count().
    // The index maps to clap_plugin_audio_ports->get_info().
+   // Input buffer and its contents are read-only.
    const clap_audio_buffer_t *audio_inputs;
    clap_audio_buffer_t       *audio_outputs;
    uint32_t                   audio_inputs_count;


### PR DESCRIPTION
A one-line addition to the documentation intended to codify the consensus in: https://github.com/free-audio/clap/discussions/152