### PR TITLE
Corrected reference to clap_plugin_audio_ports members.

### DIFF
--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -45,8 +45,8 @@ typedef struct clap_process {
    const clap_event_transport_t *transport;
 
    // Audio buffers, they must have the same count as specified
-   // by clap_plugin_audio_ports->get_count().
-   // The index maps to clap_plugin_audio_ports->get_info().
+   // by clap_plugin_audio_ports->count().
+   // The index maps to clap_plugin_audio_ports->get().
    const clap_audio_buffer_t *audio_inputs;
    clap_audio_buffer_t       *audio_outputs;
    uint32_t                   audio_inputs_count;


### PR DESCRIPTION
The correct names are now referenced in the documentation.