### PR TITLE
Expand the documentation on the parameter cookie

### DIFF
--- a/include/clap/events.h
+++ b/include/clap/events.h
@@ -166,7 +166,9 @@ typedef struct clap_event_param_value {
 
    // target parameter
    clap_id param_id; // @ref clap_param_info.id
-   void   *cookie;   // @ref clap_param_info.cookie
+   void   *cookie;   // @ref clap_param_info.cookie. Mandatory field.
+                     // This field must be the value the plugin delivered the host
+                     // for the param_id in question
 
    // target a specific note_id, port, key and channel, -1 for global
    int32_t note_id;
@@ -182,7 +184,9 @@ typedef struct clap_event_param_mod {
 
    // target parameter
    clap_id param_id; // @ref clap_param_info.id
-   void   *cookie;   // @ref clap_param_info.cookie
+   void   *cookie;   // @ref clap_param_info.cookie. Mandatory field.
+                     // This field must be the value the plugin delivered the host
+                     // for the param_id in question
 
    // target a specific note_id, port, key and channel, -1 for global
    int32_t note_id;

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -157,17 +157,18 @@ typedef struct clap_param_info {
 
    // This cookie value is optionally set by the plugin. If, however, the plugin
    // chooses to set it the host *must* set that value on every subsequent
-   // event which references a parameter. The host should view this value as
-   // a required, plugin provided, opaque, immutable value for all subsequent communications.
+   // event which references the parameter. The host should view this value as
+   // a required, plugin provided, per-param-id, opaque, immutable value for 
+   // all subsequent communications.
    //
-   // When `clap_host_params->rescan(CLAP_PARAM_RESCAN_ALL)` the cookie is
+   // When `clap_host_params->rescan(CLAP_PARAM_RESCAN_ALL)` is called the cookie is
    // invalidated and the plugin can provide a new cookie value (or the same cookie value).
    // After the plugin is destroyed, the cookie is no longer valid. 
    //
    // The host should make no assumptions about the cookie, what it points to, or if
    // any value of the cookie, including nullptr, is special.
    //
-   // The purpose to allow the plugin fast access to an internal plugin parameter
+   // The purpose is to allow the plugin fast access to an internal plugin parameter
    // data structure. For instance, if a plugin has its own internal class "MyParam"
    // you could imagine code during the CLAP setup like
    //

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -155,17 +155,31 @@ typedef struct clap_param_info {
 
    clap_param_info_flags flags;
 
-   // This value is optional and set by the plugin.
-   // Its purpose is to provide a fast access to the plugin parameter:
+   // This cookie value is optionally set by the plugin. If, however, the plugin
+   // chooses to set it the host *must* set that value on every subsequent
+   // event which references a parameter. The host should view this value as
+   // a required, plugin provided, opaque, immutable value for all subsequent communications.
    //
-   //    Parameter *p = findParameter(param_id);
-   //    param_info->cookie = p;
+   // When `clap_host_params->rescan(CLAP_PARAM_RESCAN_ALL)` the cookie is
+   // invalidated and the plugin can provide a new cookie value (or the same cookie value).
+   // After the plugin is destroyed, the cookie is no longer valid. 
    //
-   //    /* and later on */
-   //    Parameter *p = (Parameter *)cookie;
+   // The host should make no assumptions about the cookie, what it points to, or if
+   // any value of the cookie, including nullptr, is special.
    //
-   // It is invalidated on clap_host_params->rescan(CLAP_PARAM_RESCAN_ALL) and when the plugin is
-   // destroyed.
+   // The purpose to allow the plugin fast access to an internal plugin parameter
+   // data structure. For instance, if a plugin has its own internal class "MyParam"
+   // you could imagine code during the CLAP setup like
+   //
+   // auto *p = findParameter(param_id); 
+   // param_info->cookie = p;
+   //
+   // and then subsequently
+   // 
+   // auto *p = (MyParam *)cookie;
+   //
+   // This allows the plugin to avoid maintaining and using maps from plugin ids to parameter objects 
+   // during frequent events like parameter updates.
    void *cookie;
 
    // the display name


### PR DESCRIPTION
per conversation in discussino #173, expand the cookie documentation to make it clear that it is required and provided by the plugin.