### PR TITLE
Provide an installation target with CMake and pkg-config package files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/clap-config-version.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/clap")
 
+# In addition to the above generated `clap-config.cmake` file, we'll also
+# provide a pkg-config file to make it easier to consume this library in a
+# portable way
+configure_file(clap.pc.in "${CMAKE_CURRENT_BINARY_DIR}/clap.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/clap.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
 # clap-tests should always be available, to avoid build failing here and there
 # because the target doesn't exists
 add_custom_target(clap-tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ option(CLAP_BUILD_TESTS "Should CLAP build tests and the like?" OFF)
 add_library(clap-core INTERFACE)
 target_include_directories(clap-core INTERFACE include)
 
-install(DIRECTORY include DESTINATION "." OPTIONAL EXCLUDE_FROM_ALL)
+include(GNUInstallDirs)
+install(DIRECTORY "include/clap" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # clap-tests should always be available, to avoid build failing here and there
 # because the target doesn't exists

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ option(CLAP_BUILD_TESTS "Should CLAP build tests and the like?" OFF)
 # If you use clap as a submodule of your plugin you need some interface projects
 # to allow you to link
 add_library(clap INTERFACE)
-target_include_directories(clap INTERFACE include)
+target_include_directories(clap INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 # Older versions of the CLAP interfaces only defined a `clap-core` library.
 # Exposing the main library with the same name as the project makes it much
@@ -16,6 +18,8 @@ add_library(clap-core ALIAS clap)
 
 include(GNUInstallDirs)
 install(DIRECTORY "include/clap" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(TARGETS clap EXPORT clap INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(EXPORT clap DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/clap" FILE "clap-config.cmake")
 
 # clap-tests should always be available, to avoid build failing here and there
 # because the target doesn't exists

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,7 @@ project(CLAP LANGUAGES C CXX VERSION 1.1.2)
 option(CLAP_BUILD_TESTS "Should CLAP build tests and the like?" OFF)
 
 # If you use clap as a submodule of your plugin you need some interface projects
-# to allow you to link. clap-core gives you the include directory and clap-plugin-core
-# gives you the core + plugin-glue.
+# to allow you to link
 add_library(clap INTERFACE)
 target_include_directories(clap INTERFACE include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@ install(DIRECTORY "include/clap" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(TARGETS clap EXPORT clap INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(EXPORT clap DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/clap" FILE "clap-config.cmake")
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/clap-config-version.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY AnyNewerVersion)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/clap-config-version.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/clap")
+
 # clap-tests should always be available, to avoid build failing here and there
 # because the target doesn't exists
 add_custom_target(clap-tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,13 @@ option(CLAP_BUILD_TESTS "Should CLAP build tests and the like?" OFF)
 # If you use clap as a submodule of your plugin you need some interface projects
 # to allow you to link. clap-core gives you the include directory and clap-plugin-core
 # gives you the core + plugin-glue.
-add_library(clap-core INTERFACE)
-target_include_directories(clap-core INTERFACE include)
+add_library(clap INTERFACE)
+target_include_directories(clap INTERFACE include)
+
+# Older versions of the CLAP interfaces only defined a `clap-core` library.
+# Exposing the main library with the same name as the project makes it much
+# simpler for build systems to find the CLAP package.
+add_library(clap-core ALIAS clap)
 
 include(GNUInstallDirs)
 install(DIRECTORY "include/clap" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 enable_testing()
-project(CLAP C CXX)
+project(CLAP LANGUAGES C CXX VERSION 1.1.2)
 
 option(CLAP_BUILD_TESTS "Should CLAP build tests and the like?" OFF)
 

--- a/clap.pc.in
+++ b/clap.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: clap
+Description: The interface headers for the CLAP audio plugin API
+Version: @CMAKE_PROJECT_VERSION@
+
+Cflags: -I${includedir}


### PR DESCRIPTION
This makes it easier to consume CLAP using build systems that rely on either CMake's `find_package()` mechanism or on pkg-config to find package dependencies. For this to work smoothly, the main library target has been renamed to `clap` so it matches the project name. A `clap-core` alias has been provided so projects can still refer to it by that name and no existing code will break. The CMake project now also contains the CLAP version number so that applications that include the CLAP library package can check whether that version matches their supported versions.

This has been verified to work with CMake's `find_package()`, with Meson's `dependency()` (both when using the `.pc` file and the CMake config+config-version files). I've also built Surge XT against these headers to make sure nothing changes for existing projects (there shouldn't be any reason to think it would, but you never know).

This resolves #198.