### PR TITLE
Win: Correct non-existing environment variable and native directory separator

### DIFF
--- a/include/clap/entry.h
+++ b/include/clap/entry.h
@@ -16,8 +16,8 @@ extern "C" {
 //   - /usr/lib/clap
 //
 // Windows
-//   - %CommonFilesFolder%/CLAP/
-//   - %LOCALAPPDATA%/Programs/Common/CLAP/
+//   - %COMMONPROGRAMFILES%\CLAP
+//   - %LOCALAPPDATA%\Programs\Common\CLAP
 //
 // MacOS
 //   - /Library/Audio/Plug-Ins/CLAP


### PR DESCRIPTION
This PR improves two things in the `entry.h` file's comment section:
- On Windows, the system-wide default deployment path for CLAP plugins is `C:\Program Files\Common Files\CLAP`, which is stored in the environment variable `%COMMONPROGRAMFILES%`. However, the comment section in `entry.h` specifies a wrong (non-existing) environment variable to be used.  
- The directory separator on Windows is `\` but the comment section uses the *nix directory separator `/` for Windows paths.