### PR TITLE
Fix a typo in ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@
 * [file-reference.h](include/clap/ext/draft/file-reference.h): improve documentation
 * [params.h](include/clap/ext/params.h): clarify how the cookie works and add some notes about `flush()`
 * [process.h](include/clap/process.h): clarify how the audio buffer mapping works
-* [gui.h](include/clap/ext/gui.h): clarify `clap_plugin_gui.get_preferred_agi()`
+* [gui.h](include/clap/ext/gui.h): clarify `clap_plugin_gui.get_preferred_api()`
 * [plugin-factory.h](include/clap/plugin-factory.h): mention `clap_plugin_invalidation_factory` which can be use to invalidate cached entries
 
 # Changes in 1.1.1


### PR DESCRIPTION
`clap_plugin_gui.get_preferred_agi()` to `clap_plugin_gui.get_preferred_api()`