### PR TITLE
Document more precise use of param name vs module

### DIFF
--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -221,11 +221,13 @@ typedef struct clap_param_info {
    //    per event.
    void *cookie;
 
-   // the display name
+   // The display name. eg: "Volume". This does not need to be unique. Do not include the module
+   // text in this. The host should concatenate/format the module + name in the case where showing
+   // the name alone would be too vague.
    char name[CLAP_NAME_SIZE];
 
-   // the module path containing the param, eg:"oscillators/wt1"
-   // '/' will be used as a separator to show a tree like structure.
+   // The module path containing the param, eg: "Oscillators/Wavetable 1".
+   // '/' will be used as a separator to show a tree-like structure.
    char module[CLAP_PATH_SIZE];
 
    double min_value;     // minimum plain value


### PR DESCRIPTION
Following the discussion: https://github.com/free-audio/clap/discussions/248#discussion-4683110

There was a slight consenus towards ensuring that the `name` field does not also contain the text of the `module`. Instead, the host should somehow display `module` alongside `name` if `name` alone would be too vague.

This PR suggests putting these rules into the header comments. It's separate from my other PR as it might be more controversial.