### PR TITLE
Fix typos in API

### DIFF
--- a/include/clap/events.h
+++ b/include/clap/events.h
@@ -54,8 +54,8 @@ enum {
    // cases:
    // - a plugin is inside a drum pad in Bitwig Studio's drum machine, and this pad is choked by
    //   another one
-   // - the user double clicks the DAW's stop button in the transport which then stops the sound on
-   //   every tracks
+   // - the user double-clicks the DAW's stop button in the transport which then stops the sound on
+   //   every track
    //
    // NOTE_END is sent by the plugin to the host. The port, channel, key and note_id are those given
    // by the host in the NOTE_ON event. In other words, this event is matched against the
@@ -221,7 +221,7 @@ typedef struct clap_event_transport {
    clap_sectime  song_pos_seconds; // position in seconds
 
    double tempo;     // in bpm
-   double tempo_inc; // tempo increment for each samples and until the next
+   double tempo_inc; // tempo increment for each sample and until the next
                      // time info event
 
    clap_beattime loop_start_beats;

--- a/include/clap/ext/audio-ports-config.h
+++ b/include/clap/ext/audio-ports-config.h
@@ -80,7 +80,7 @@ typedef struct clap_plugin_audio_ports_config_info {
    // [main-thread]
    clap_id(CLAP_ABI *current_config)(const clap_plugin_t *plugin);
 
-   // Get info about about an audio port, for a given config_id.
+   // Get info about an audio port, for a given config_id.
    // This is analogous to clap_plugin_audio_ports.get().
    // [main-thread]
    bool(CLAP_ABI *get)(const clap_plugin_t    *plugin,

--- a/include/clap/ext/draft/context-menu.h
+++ b/include/clap/ext/draft/context-menu.h
@@ -136,7 +136,7 @@ typedef struct clap_host_context_menu {
                            clap_id                           action_id);
 
    // Returns true if the host can display a popup menu for the plugin.
-   // This may depends upon the current windowing system used to display the plugin, so the
+   // This may depend upon the current windowing system used to display the plugin, so the
    // return value is invalidated after creating the plugin window.
    // [main-thread]
    bool(CLAP_ABI *can_popup)(const clap_host_t *host);

--- a/include/clap/ext/draft/param-indication.h
+++ b/include/clap/ext/draft/param-indication.h
@@ -32,7 +32,7 @@ enum {
    // The host is recording an automation on this parameter
    CLAP_PARAM_INDICATION_AUTOMATION_RECORDING = 3,
 
-   // The host should play an automation for this parameter, but the user has started to ajust this
+   // The host should play an automation for this parameter, but the user has started to adjust this
    // parameter and is overriding the automation playback
    CLAP_PARAM_INDICATION_AUTOMATION_OVERRIDING = 4,
 };

--- a/include/clap/ext/draft/remote-controls.h
+++ b/include/clap/ext/draft/remote-controls.h
@@ -67,7 +67,7 @@ typedef struct clap_host_remote_controls {
    // [main-thread]
    void(CLAP_ABI *changed)(const clap_host_t *host);
 
-   // Suggest a page to the host because it correspond to what the user is currently editing in the
+   // Suggest a page to the host because it corresponds to what the user is currently editing in the
    // plugin's GUI.
    // [main-thread]
    void(CLAP_ABI *suggest_page)(const clap_host_t *host, clap_id page_id);

--- a/include/clap/ext/draft/resource-directory.h
+++ b/include/clap/ext/draft/resource-directory.h
@@ -24,7 +24,7 @@ extern "C" {
 ///   -> suitable for read-write content
 ///
 /// Keeping the shared directory clean:
-/// - to avoid clashes in the shared directory, plugins are encourraged to organize their files in
+/// - to avoid clashes in the shared directory, plugins are encouraged to organize their files in
 ///   sub-folders, for example create one subdirectory using the vendor name
 /// - don't use symbolic links or hard links which points outside of the directory
 ///
@@ -35,7 +35,7 @@ extern "C" {
 ///   are removed from the project
 ///
 /// Note for the host
-/// - try to use the filesytem's copy-on-write feature when possible for reducing exclusive folder
+/// - try to use the filesystem's copy-on-write feature when possible for reducing exclusive folder
 ///   space usage on duplication
 /// - host can "garbage collect" the files in the shared folder using:
 ///     clap_plugin_resource_directory.get_files_count()

--- a/include/clap/ext/draft/resource-directory.h
+++ b/include/clap/ext/draft/resource-directory.h
@@ -50,7 +50,7 @@ typedef struct clap_plugin_resource_directory {
    // [main-thread]
    void(CLAP_ABI *set_directory)(const clap_plugin_t *plugin, const char *path, bool is_shared);
 
-   // Asks the plugin to put its resources into the resources directory.
+   // Asks the plugin to put its resources into the resource directory.
    // It is not necessary to collect files which belongs to the plugin's
    // factory content unless the param all is true.
    // [main-thread]
@@ -60,7 +60,7 @@ typedef struct clap_plugin_resource_directory {
    // [main-thread]
    uint32_t(CLAP_ABI *get_files_count)(const clap_plugin_t *plugin);
 
-   // Retrieves relative file path to the resources directory.
+   // Retrieves relative file path to the resource directory.
    // @param path writable memory to store the path
    // @param path_size number of available bytes in path
    // Returns the number of bytes in the path, or -1 on error

--- a/include/clap/ext/draft/surround.h
+++ b/include/clap/ext/draft/surround.h
@@ -54,7 +54,7 @@ enum {
 };
 
 typedef struct clap_plugin_surround {
-   // Stores into the channel_map array, the surround identifier of each channels.
+   // Stores into the channel_map array, the surround identifier of each channel.
    // Returns the number of elements stored in channel_map.
    //
    // config_id: the configuration id, see clap_plugin_audio_ports_config.

--- a/include/clap/ext/draft/surround.h
+++ b/include/clap/ext/draft/surround.h
@@ -54,7 +54,7 @@ enum {
 };
 
 typedef struct clap_plugin_surround {
-   // Stores into the channel_map array, the surround identifer of each channels.
+   // Stores into the channel_map array, the surround identifier of each channels.
    // Returns the number of elements stored in channel_map.
    //
    // config_id: the configuration id, see clap_plugin_audio_ports_config.
@@ -78,7 +78,7 @@ typedef struct clap_host_surround {
    // [main-thread]
    void(CLAP_ABI *changed)(const clap_host_t *host);
 
-   // Ask the host what is the prefered/project surround channel map.
+   // Ask the host what is the preferred/project surround channel map.
    // [main-thread]
    void(CLAP_ABI *get_preferred_channel_map)(const clap_host_t *host,
                                              uint8_t           *channel_map,

--- a/include/clap/ext/draft/track-info.h
+++ b/include/clap/ext/draft/track-info.h
@@ -4,7 +4,7 @@
 #include "../../color.h"
 #include "../../string-sizes.h"
 
-// This extensions let the plugin query info about the track it's in.
+// This extension let the plugin query info about the track it's in.
 // It is useful when the plugin is created, to initialize some parameters (mix, dry, wet)
 // and pick a suitable configuration regarding audio port type and channel count.
 

--- a/include/clap/ext/draft/track-info.h
+++ b/include/clap/ext/draft/track-info.h
@@ -6,7 +6,7 @@
 
 // This extensions let the plugin query info about the track it's in.
 // It is useful when the plugin is created, to initialize some parameters (mix, dry, wet)
-// and pick a suitable configuartion regarding audio port type and channel count.
+// and pick a suitable configuration regarding audio port type and channel count.
 
 static CLAP_CONSTEXPR const char CLAP_EXT_TRACK_INFO[] = "clap.track-info.draft/1";
 
@@ -38,7 +38,7 @@ typedef struct clap_track_info {
    // track color, available if flags contain CLAP_TRACK_INFO_HAS_TRACK_COLOR
    clap_color_t color;
 
-   // availabe if flags contain CLAP_TRACK_INFO_HAS_AUDIO_CHANNEL
+   // available if flags contain CLAP_TRACK_INFO_HAS_AUDIO_CHANNEL
    // see audio-ports.h, struct clap_audio_port_info to learn how to use channel count and port type
    int32_t     audio_channel_count;
    const char *audio_port_type;

--- a/include/clap/ext/draft/tuning.h
+++ b/include/clap/ext/draft/tuning.h
@@ -39,9 +39,9 @@ typedef struct clap_host_tuning {
    // The plugin may query the tuning at a rate that makes sense for *low* frequency modulations.
    //
    // If the tuning_id is not found or equals to CLAP_INVALID_ID,
-   // then the function shall gracefuly return a sensible value.
+   // then the function shall gracefully return a sensible value.
    //
-   // sample_offset is the sample offset from the begining of the current process block.
+   // sample_offset is the sample offset from the beginning of the current process block.
    //
    // should_play(...) should be checked before calling this function.
    //

--- a/include/clap/ext/gui.h
+++ b/include/clap/ext/gui.h
@@ -99,7 +99,7 @@ typedef struct clap_plugin_gui {
    bool(CLAP_ABI *is_api_supported)(const clap_plugin_t *plugin, const char *api, bool is_floating);
 
    // Returns true if the plugin has a preferred api.
-   // The host has no obligation to honor the plugin preferrence, this is just a hint.
+   // The host has no obligation to honor the plugin preference, this is just a hint.
    // The const char **api variable should be explicitly assigned as a pointer to
    // one of the CLAP_WINDOW_API_ constants defined above, not strcopied.
    // [main-thread]
@@ -113,7 +113,7 @@ typedef struct clap_plugin_gui {
    // can set its window to stays above the parent window, see set_transient().
    // api may be null or blank for floating window.
    //
-   // If is_floating is false, then the plugin has to embbed its window into the parent window, see
+   // If is_floating is false, then the plugin has to embed its window into the parent window, see
    // set_parent().
    //
    // After this call, the GUI may not be visible yet; don't forget to call show().
@@ -161,7 +161,7 @@ typedef struct clap_plugin_gui {
    // [main-thread]
    bool(CLAP_ABI *set_size)(const clap_plugin_t *plugin, uint32_t width, uint32_t height);
 
-   // Embbeds the plugin window into the given window.
+   // Embeds the plugin window into the given window.
    // [main-thread & !floating]
    bool(CLAP_ABI *set_parent)(const clap_plugin_t *plugin, const clap_window_t *window);
 

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -21,7 +21,7 @@
 ///
 /// When the plugin changes a parameter value, it must inform the host.
 /// It will send @ref CLAP_EVENT_PARAM_VALUE event during process() or flush().
-/// If the user is adjusting the value, don't forget to mark the begining and end
+/// If the user is adjusting the value, don't forget to mark the beginning and end
 /// of the gesture by sending CLAP_EVENT_PARAM_GESTURE_BEGIN and CLAP_EVENT_PARAM_GESTURE_END
 /// events.
 ///
@@ -74,7 +74,7 @@
 ///     call clap_host_params.clear(host, param_id, CLAP_PARAM_CLEAR_ALL)
 ///   - call clap_host_params->rescan(CLAP_PARAM_RESCAN_ALL)
 ///
-/// CLAP allows the plugin to change the parameter range, yet the plugin developper
+/// CLAP allows the plugin to change the parameter range, yet the plugin developer
 /// should be aware that doing so isn't without risk, especially if you made the
 /// promise to never change the sound. If you want to be 100% certain that the
 /// sound will not change with all host, then simply never change the range.
@@ -89,7 +89,7 @@
 /// should be stored as plain value in the document.
 ///
 /// If the host goes with the first approach, there will still be situation where the
-/// sound may innevitably change. For example, if the plugin increase the range, there
+/// sound may inevitably change. For example, if the plugin increase the range, there
 /// is an automation playing at the max value and on top of that an LFO is applied.
 /// See the following curve:
 ///                                   .

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -120,7 +120,7 @@ enum {
    // if so the double value is converted to integer using a cast (equivalent to trunc).
    CLAP_PARAM_IS_STEPPED = 1 << 0,
 
-   // Useful for for periodic parameters like a phase
+   // Useful for periodic parameters like a phase
    CLAP_PARAM_IS_PERIODIC = 1 << 1,
 
    // The parameter should not be shown to the user, because it is currently not used.
@@ -191,7 +191,7 @@ typedef struct clap_param_info {
    clap_param_info_flags flags;
 
    // This value is optional and set by the plugin.
-   // Its purpose is to provide a fast access to the plugin parameter object by caching its pointer.
+   // Its purpose is to provide fast access to the plugin parameter object by caching its pointer.
    // For instance:
    //
    // in clap_plugin_params.get_info():

--- a/include/clap/ext/posix-fd-support.h
+++ b/include/clap/ext/posix-fd-support.h
@@ -24,7 +24,7 @@ typedef struct clap_plugin_posix_fd_support {
    // This callback is "level-triggered".
    // It means that a writable fd will continuously produce "on_fd()" events;
    // don't forget using modify_fd() to remove the write notification once you're
-   // done writting.
+   // done writing.
    //
    // [main-thread]
    void(CLAP_ABI *on_fd)(const clap_plugin_t *plugin, int fd, clap_posix_fd_flags_t flags);

--- a/include/clap/ext/render.h
+++ b/include/clap/ext/render.h
@@ -24,7 +24,7 @@ typedef int32_t clap_plugin_render_mode;
 // If this information does not influence your rendering code, then don't
 // implement this extension.
 typedef struct clap_plugin_render {
-   // Returns true if the plugin has an hard requirement to process in real-time.
+   // Returns true if the plugin has a hard requirement to process in real-time.
    // This is especially useful for plugin acting as a proxy to an hardware device.
    // [main-thread]
    bool(CLAP_ABI *has_hard_realtime_requirement)(const clap_plugin_t *plugin);

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -29,7 +29,7 @@ extern "C" {
 ///    thread pool and the plugin.process() call may be scheduled on different OS threads over time.
 ///    The most important thing is that there can't be two audio-threads at the same time. All the
 ///    functions marked with [audio-thread] **ARE NOT CONCURRENT**. The host may mark any OS thread,
-///    including the main-thread as the audio-thread, as long as it can guarentee that only one OS
+///    including the main-thread as the audio-thread, as long as it can guarantee that only one OS
 ///    thread is the audio-thread at a time. The audio-thread can be seen as a concurrency guard for
 ///    all functions marked with [audio-thread].
 

--- a/include/clap/factory/draft/preset-discovery.h
+++ b/include/clap/factory/draft/preset-discovery.h
@@ -62,7 +62,7 @@ enum clap_preset_discovery_flags {
    CLAP_PRESET_DISCOVERY_IS_USER_CONTENT = 1 << 1,
 
    // This location is meant for demo presets, those are preset which may trigger
-   // some limitation in the plugin because they require additionnal features which the user
+   // some limitation in the plugin because they require additional features which the user
    // needs to purchase or the content itself needs to be bought and is only available in
    // demo mode.
    CLAP_PRESET_DISCOVERY_IS_DEMO_CONTENT = 1 << 2,
@@ -282,7 +282,7 @@ typedef struct clap_preset_discovery_indexer {
 } clap_preset_discovery_indexer_t;
 
 // Every methods in this factory must be thread-safe.
-// It is encourraged to perform preset indexing in background threads, maybe even in background
+// It is encouraged to perform preset indexing in background threads, maybe even in background
 // process.
 //
 // The host may use clap_plugin_invalidation_factory to detect filesystem changes

--- a/include/clap/plugin-features.h
+++ b/include/clap/plugin-features.h
@@ -6,7 +6,7 @@
 // For practical reasons we'll avoid spaces and use `-` instead to facilitate
 // scripts that generate the feature array.
 //
-// Non-standard features should be formated as follow: "$namespace:$feature"
+// Non-standard features should be formatted as follow: "$namespace:$feature"
 
 /////////////////////
 // Plugin category //

--- a/include/clap/plugin.h
+++ b/include/clap/plugin.h
@@ -16,7 +16,7 @@ typedef struct clap_plugin_descriptor {
    // Otherwise the fields can be null or blank, though it is safer to make them blank.
    //
    // Some indications regarding id and version
-   // - id is an arbritrary string which should be unique to your plugin,
+   // - id is an arbritray string which should be unique to your plugin,
    //   we encourage you to use a reverse URI eg: "com.u-he.diva"
    // - version is an arbitrary string which describes a plugin,
    //   it is useful for the host to understand and be able to compare two different
@@ -77,7 +77,7 @@ typedef struct clap_plugin {
    void(CLAP_ABI *stop_processing)(const struct clap_plugin *plugin);
 
    // - Clears all buffers, performs a full reset of the processing state (filters, oscillators,
-   //   enveloppes, lfo, ...) and kills all voices.
+   //   envelopes, lfo, ...) and kills all voices.
    // - The parameter's value remain unchanged.
    // - clap_process.steady_time may jump backward.
    //

--- a/include/clap/version.h
+++ b/include/clap/version.h
@@ -10,7 +10,7 @@ extern "C" {
 typedef struct clap_version {
    // This is the major ABI and API design
    // Version 0.X.Y correspond to the development stage, API and ABI are not stable
-   // Version 1.X.Y correspont to the release stage, API and ABI are stable
+   // Version 1.X.Y correspond to the release stage, API and ABI are stable
    uint32_t major;
    uint32_t minor;
    uint32_t revision;


### PR DESCRIPTION
I was going through the API and fixed some typos along the way.