### PR TITLE
Add the ability for plugins to opt-in to asyncronous state calls

### DIFF
--- a/include/clap/ext/draft/state-context.h
+++ b/include/clap/ext/draft/state-context.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context.draft/1";
+static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context.draft/2";
 
 enum clap_plugin_state_context_type {
    // suitable for duplicating a plugin instance
@@ -43,7 +43,7 @@ typedef struct clap_plugin_state_context {
    //
    // Note that the result may be loaded by both clap_plugin_state.load() and
    // clap_plugin_state_context.load().
-   // [main-thread]
+   // [state-thread]
    bool(CLAP_ABI *save)(const clap_plugin_t  *plugin,
                         const clap_ostream_t *stream,
                         uint32_t              context_type);
@@ -53,10 +53,23 @@ typedef struct clap_plugin_state_context {
    //
    // Note that the state may have been saved by clap_plugin_state.save() or
    // clap_plugin_state_context.save() with a different context_type.
-   // [main-thread]
+   // [state-thread]
    bool(CLAP_ABI *load)(const clap_plugin_t  *plugin,
                         const clap_istream_t *stream,
                         uint32_t              context_type);
+
+   // Indicates whether or not the plugin can support having a state-thread
+   // that is different than the main-thread.
+   //
+   // If this returns false, state-thread will always be the same as the
+   // main-thread.
+   //
+   // If this returns true, the state-thread may be a different thread than
+   // the main-thread.
+   //
+   // This must return the same result throughout the lifetime of the plugin.
+   // [thread-safe]
+   bool (CLAP_ABI *supports_async_state)(const clap_plugin_t *plugin);
 } clap_plugin_state_context_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -10,7 +10,7 @@ extern "C" {
 
 /// @page thread-check
 ///
-/// CLAP defines two symbolic threads:
+/// CLAP defines three symbolic threads:
 ///
 /// main-thread:
 ///    This is the thread in which most of the interaction between the plugin and host happens.
@@ -32,6 +32,12 @@ extern "C" {
 ///    including the main-thread as the audio-thread, as long as it can guarantee that only one OS
 ///    thread is the audio-thread at a time. The audio-thread can be seen as a concurrency guard for
 ///    all functions marked with [audio-thread].
+///
+/// state-thread:
+///    This thread is used for saving and loading plugin state. For plug-ins that don't support
+///    CLAP_EXT_STATE_CONTEXT, as well as plugins that return false from `supports_async_state`,
+///    this thread is always the same as the main-thread.
+///    For plugins
 
 // This interface is useful to do runtime checks and make
 // sure that the functions are called on the correct threads.


### PR DESCRIPTION
This adds a new function on state-context that allows the plugin to opt in to receiving save and load calls on a new "state-thread" symbolic thread. Hosts could use this to parallelize loading and saving session state, which can greatly reduce the time it takes to load or save a large session.

This came out of discussion on #255, and is opened as a PR in the hopes that looking at a concrete change proposal is more productive than discussing in the abstract.  I'm happy to reject this and continue the discussion somewhere else if that's more appropriate.

Currently left unaddressed is the idea of activating also on a background thread, raised [in this comment](https://github.com/free-audio/clap/pull/255#issuecomment-1464004269).  I could use ideas on how to allow this.  Perhaps `state-thread` is not a good idea and it should be called `bg-thread` or something like that?