### PR TITLE
GUI extension: !floating tag

### DIFF
--- a/include/clap/ext/gui.h
+++ b/include/clap/ext/gui.h
@@ -147,8 +147,7 @@ typedef struct clap_plugin_gui {
    bool(CLAP_ABI *get_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
 
    // Returns true if the window is resizeable (mouse drag).
-   // Only for embedded windows.
-   // [main-thread]
+   // [main-thread & !floating]
    bool(CLAP_ABI *can_resize)(const clap_plugin_t *plugin);
 
    // Returns true if the plugin can provide hints on how to resize the window.
@@ -159,16 +158,14 @@ typedef struct clap_plugin_gui {
    // usable size which fits in the given size.
    // This method does not change the size.
    //
-   // Only for embedded windows.
-   //
    // Returns true if the plugin could adjust the given size.
-   // [main-thread]
+   // [main-thread & !floating]
    bool(CLAP_ABI *adjust_size)(const clap_plugin_t *plugin, uint32_t *width, uint32_t *height);
 
-   // Sets the window size. Only for embedded windows.
+   // Sets the window size.
    //
    // Returns true if the plugin could resize its window to the given size.
-   // [main-thread]
+   // [main-thread & !floating]
    bool(CLAP_ABI *set_size)(const clap_plugin_t *plugin, uint32_t width, uint32_t height);
 
    // Embeds the plugin window into the given window.
@@ -215,7 +212,7 @@ typedef struct clap_host_gui {
     * acknowledged the request and will process it asynchronously. If the request then can't be
     * satisfied then the host will call set_size() to revert the operation.
     *
-    * [thread-safe] */
+    * [thread-safe & !floating] */
    bool(CLAP_ABI *request_resize)(const clap_host_t *host, uint32_t width, uint32_t height);
 
    /* Request the host to show the plugin gui.

--- a/include/clap/ext/gui.h
+++ b/include/clap/ext/gui.h
@@ -151,7 +151,7 @@ typedef struct clap_plugin_gui {
    bool(CLAP_ABI *can_resize)(const clap_plugin_t *plugin);
 
    // Returns true if the plugin can provide hints on how to resize the window.
-   // [main-thread]
+   // [main-thread & !floating]
    bool(CLAP_ABI *get_resize_hints)(const clap_plugin_t *plugin, clap_gui_resize_hints_t *hints);
 
    // If the plugin gui is resizable, then the plugin will calculate the closest
@@ -201,7 +201,7 @@ typedef struct clap_plugin_gui {
 
 typedef struct clap_host_gui {
    // The host should call get_resize_hints() again.
-   // [thread-safe]
+   // [thread-safe & !floating]
    void(CLAP_ABI *resize_hints_changed)(const clap_host_t *host);
 
    /* Request the host to resize the client area to width, height.


### PR DESCRIPTION
PR for issue #313 

Concerning `get_resize_hints` and `resize_hints_changed`:

- Probably for another issue/PR: I just wondered that those methods are not mentioned in the rest of the documentation. When just reading the comments next to the methods themselves, I don't know when and why they get called.
- But I hope I got it right to assign the !floating tag to them as well ❓ 