### PR TITLE
Fix C++ version checking on MSVC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,8 +39,17 @@ jobs:
 
       - name: Run CMake+Ninja+CTest to generate/build/test.
         uses: lukka/run-cmake@v10
-        id: runcmake
+        id: runcmake-ninja
         with:
           configurePreset: 'ninja'
           buildPreset: 'ninja-release'
           testPreset: 'ninja-release'
+
+      - name: Run CMake+MSVC+CTest to generate/build/test.
+        uses: lukka/run-cmake@v10
+        if: startsWith(matrix.os, 'win')
+        id: runcmake-msvc
+        with:
+          configurePreset: 'msvc'
+          buildPreset: 'msvc-release'
+          testPreset: 'msvc-release'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ if (${CLAP_BUILD_TESTS})
         add_test(NAME test-clap-compile-${SUFFIX} COMMAND clap-compile-${SUFFIX})
         add_dependencies(clap-tests clap-compile-${SUFFIX})
 
+        if (${EXT} STREQUAL "cc")
+            target_compile_definitions(clap-compile-${SUFFIX} PRIVATE CLAP_COMPILE_TEST_CXX_VERSION=${STDCPP})
+        endif()
+
         if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
             target_compile_options(clap-compile-${SUFFIX} PRIVATE -Wall -Wextra -pedantic)
         endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,23 @@
           "value": true
         }
       }
+    },
+    {
+      "name": "msvc",
+      "displayName": "MSVC",
+      "description": "Configure and generate MSVC project files for all configurations",
+      "binaryDir": "${sourceDir}/builds/${presetName}",
+      "generator": "Visual Studio 17 2022",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {
+          "type": "boolean",
+          "value": true
+        },
+        "CLAP_BUILD_TESTS": {
+          "type": "boolean",
+          "value": true
+        }
+      }
     }
   ],
   "buildPresets": [
@@ -32,12 +49,25 @@
       "description": "Build ninja Release configuration",
       "configuration": "RelWithDebInfo",
       "targets": ["clap-tests"]
+    },
+    {
+      "name": "msvc-release",
+      "configurePreset": "msvc",
+      "displayName": "Build msvc-release",
+      "description": "Build msvc Release configuration",
+      "configuration": "RelWithDebInfo",
+      "targets": ["clap-tests"]
     }
   ],
   "testPresets": [
     {
       "name": "ninja-release",
       "configurePreset": "ninja",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "msvc-release",
+      "configurePreset": "msvc",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -25,20 +25,28 @@
 #   endif
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
+#if defined(__cplusplus)
+#   if MSVC
+#      define CLAP_CPLUSPLUS _MSVC_LANG
+#   else
+#      define CLAP_CPLUSPLUS __cplusplus
+#   endif
+#endif
+
+#if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 201103L
 #   define CLAP_HAS_CXX11
 #   define CLAP_CONSTEXPR constexpr
 #else
 #   define CLAP_CONSTEXPR
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201703L
+#if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 201703L
 #   define CLAP_HAS_CXX17
 #   define CLAP_NODISCARD [[nodiscard]]
 #else
 #   define CLAP_NODISCARD
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 202002L
+#if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 202002L
 #   define CLAP_HAS_CXX20
 #endif

--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -25,12 +25,10 @@
 #   endif
 #endif
 
-#if defined(__cplusplus)
-#   if MSVC
-#      define CLAP_CPLUSPLUS _MSVC_LANG
-#   else
-#      define CLAP_CPLUSPLUS __cplusplus
-#   endif
+#if defined(_MSVC_LANG)
+#   define CLAP_CPLUSPLUS _MSVC_LANG
+#elif defined(__cplusplus)
+#   define CLAP_CPLUSPLUS __cplusplus
 #endif
 
 #if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 201103L

--- a/src/main.cc
+++ b/src/main.cc
@@ -48,6 +48,18 @@
 #error CLAP_VERSION_LT is inconsistent (REVISION)
 #endif
 
+#if (CLAP_COMPILE_TEST_CXX_VERSION >= 11) && ! defined(CLAP_HAS_CXX11)
+#error CLAP_HAS_CXX11 is not defined correctly
+#endif
+
+#if (CLAP_COMPILE_TEST_CXX_VERSION >= 17) && ! defined(CLAP_HAS_CXX17)
+#error CLAP_HAS_CXX17 is not defined correctly
+#endif
+
+#if (CLAP_COMPILE_TEST_CXX_VERSION >= 20) && ! defined(CLAP_HAS_CXX20)
+#error CLAP_HAS_CXX20 is not defined correctly
+#endif
+
 static const CLAP_CONSTEXPR clap_version m = CLAP_VERSION;
 
 int main(int, char **) {


### PR DESCRIPTION
I've also added some tests to check that the C++ version checking is working correctly, as well as a CI step for building/testing with MSVC. Unfortunately, the MSVC CI builds take significantly longer than any of the others (like 3-5 minutes as opposed to ~30 seconds), so I understand if you'd rather we skip those for now.