### PR TITLE
Add flag for enum parameters

### DIFF
--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -195,6 +195,12 @@ enum {
    // A simple example would be a DC Offset, changing it will change the output signal and must be
    // processed.
    CLAP_PARAM_REQUIRES_PROCESS = 1 << 15,
+
+   // The parameter represents a set of named options mapped to integers.
+   // It implies that the parameter is stepped.
+   //
+   // This flag may help the host decide how to present the parameter to users.
+   CLAP_PARAM_IS_ENUM = 1 << 16,
 };
 typedef uint32_t clap_param_info_flags;
 

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -196,10 +196,9 @@ enum {
    // processed.
    CLAP_PARAM_REQUIRES_PROCESS = 1 << 15,
 
-   // The parameter represents a set of named options mapped to integers.
-   // It implies that the parameter is stepped.
-   //
-   // This flag may help the host decide how to present the parameter to users.
+   // Indicates that this parameter represents an enumerated value.
+   // If you set this flag, then you must set CLAP_PARAM_IS_STEPPED too.
+   // All values from min to max must have a non blank value_to_text().
    CLAP_PARAM_IS_ENUM = 1 << 16,
 };
 typedef uint32_t clap_param_info_flags;


### PR DESCRIPTION
See the proposal here: https://github.com/free-audio/clap/discussions/357

This PR adds a `CLAP_PARAM_IS_ENUM` flag to `clap_param_info_flags` to denote an enum parameter.

This flag tells the host when a parameter represents a set of named options mapped to integers, which can help the host decide how to present the parameter to users in its UI.
