### PR TITLE
Unlikely

### DIFF
--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -47,4 +47,7 @@
 
 #if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 202002L
 #   define CLAP_HAS_CXX20
+#   define CLAP_UNLIKELY [[unlikely]]
+#else
+#   define CLAP_UNLIKELY
 #endif


### PR DESCRIPTION
the `unlikely` attribute is used in the `clap-host` repo but is C++20 or higher (so not C++17 friendly)

I guess it's good to define it here(?)
Or should it rather be in the `clap-host` repository?