### PR TITLE
Clarify the allowed usages of clap_plugin_entry's init() and deinit()

### DIFF
--- a/include/clap/entry.h
+++ b/include/clap/entry.h
@@ -30,35 +30,63 @@ extern "C" {
 //
 // Each directory should be recursively searched for files and/or bundles as appropriate in your OS
 // ending with the extension `.clap`.
-//
-// Every method must be thread-safe.
 typedef struct clap_plugin_entry {
    clap_version_t clap_version; // initialized to CLAP_VERSION
 
-   // This function must be called first, and can only be called once.
+   // Initializes the DSO.
+   //
+   // This function must be called first, before any-other CLAP-related function or symbol from this
+   // DSO.
+   //
+   // It also must only be called once, until a later call to deinit() is made, after which init()
+   // can be called once more to re-initialize the DSO.
+   // This enables hosts to e.g. quickly load and unload a DSO for scanning its plugins, and then
+   // load it again later to actually use the plugins if needed.
    //
    // It should be as fast as possible, in order to perform a very quick scan of the plugin
    // descriptors.
    //
-   // It is forbidden to display graphical user interface in this call.
-   // It is forbidden to perform user interaction in this call.
+   // It is forbidden to display graphical user interfaces in this call.
+   // It is forbidden to perform any user interaction in this call.
    //
    // If the initialization depends upon expensive computation, maybe try to do them ahead of time
    // and cache the result.
    //
-   // If init() returns false, then the host must not call deinit() nor any other clap
-   // related symbols from the DSO.
+   // Returns true on success. If init() returns false, then the DSO must be considered
+   // uninitialized, and the host must not call deinit() nor any other CLAP-related symbols from the
+   // DSO.
    //
    // plugin_path is the path to the DSO (Linux, Windows), or the bundle (macOS).
+   //
+   // This function may be called on any thread, including a different one from the one a later call
+   // to deinit() (or a later init()) can be made.
+   // However, it is forbidden to call this function simultaneously from multiple threads.
+   // It is also forbidden to call it simultaneously with *any* other CLAP-related symbols from the
+   // DSO, including (but not limited to) deinit().
    bool(CLAP_ABI *init)(const char *plugin_path);
 
-   // No more calls into the DSO must be made after calling deinit().
+   // De-initializes the DSO, freeing any resources allocated or initialized by init().
+   //
+   // After this function is called, no more calls into the DSO must be made, except calling init()
+   // again to re-initialize the DSO.
+   // This means that after deinit() is called, the DSO can be considered to be in the same state
+   // as if init() was never called at all yet, enabling it to be re-initialized as needed.
+   //
+   // Just like init(), this function may be called on any thread, including a different one from
+   // the one init() was called from, or from the one a later init() call can be made.
+   // However, it is forbidden to call this function simultaneously from multiple threads.
+   // It is also forbidden to call it simultaneously with *any* other CLAP-related symbols from the
+   // DSO, including (but not limited to) deinit().
    void(CLAP_ABI *deinit)(void);
 
    // Get the pointer to a factory. See factory/plugin-factory.h for an example.
    //
    // Returns null if the factory is not provided.
    // The returned pointer must *not* be freed by the caller.
+   //
+   // Unlike init() and deinit(), this function can be called simultaneously by multiple threads.
+   //
+   // [thread-safe]
    const void *(CLAP_ABI *get_factory)(const char *factory_id);
 } clap_plugin_entry_t;
 


### PR DESCRIPTION
This PR is a followup to the discussion in #365, and clarifies the following points in the specification of `clap_plugin_entry`:

* Assert that a CLAP DSO *can* be re-`init`ialized after it has been `deinit`ialized.
  
   The specification currently states that `init` "can only be called once", and that `deinit` prevents "[any] more calls to into the DSO". These can be interpreted as "`init` can only be called once ever" and "nothing in the DSO cannot be used ever again after `deinit`", which would be an odd requirement, and indeed seems not to be the intent of the spec according to the discussion in #365.

   This PR changes those statements to clearly indicate that re-initialization is allowed, while still forbidding to call `init` and `deinit` again if the DSO has already been initialized/de-initialized respectively (which I believe is the intent of the original wording).
* Replace the assertion that confusingly marks `init` and `deinit` as "thread-safe", with a more specific explanation of the threading rules for these two functions.
  
  Using the "thread-safe" term is confusing here because it is usually interpreted as "can be safely called simultaneously from multiple threads", but consecutive calls to these functions are explicitly forbidden, let alone simultaneous ones.

   This is replaced with a more detailed definition, which explicitly forbids simultaneous calls, while also explaining that the host may call `init` and `deinit` from any (and different) threads.

   This PR also makes it explicit that those threading requirements do not apply to `get_factory`, which is thread-safe, and now uses the standard `[thread-safe]` thread specification.

I also took the liberty to fix a couple of unrelated typos in those specifications. :slightly_smiling_face: 