### PR TITLE
added project load as explicit option

### DIFF
--- a/include/clap/ext/state-context.h
+++ b/include/clap/ext/state-context.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context.draft/2";
+static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context/2";
 
 enum clap_plugin_state_context_type {
    // suitable for loading a state as a preset

--- a/include/clap/ext/state-context.h
+++ b/include/clap/ext/state-context.h
@@ -10,7 +10,8 @@
 /// on the context.
 ///
 /// Briefly, when loading a preset or duplicating a device, the plugin may want to partially load
-/// the state and initialize certain things differently.
+/// the state and initialize certain things differently, like handling limited resources or fixed
+/// connections to external hardware resources.
 ///
 /// Save and Load operations may have a different context.
 /// All three operations should be equivalent:
@@ -20,6 +21,8 @@
 ///        clap_plugin_state_context.save(CLAP_STATE_CONTEXT_FOR_PRESET),
 ///        CLAP_STATE_CONTEXT_FOR_PRESET)
 ///
+/// If in doubt, choose CLAP_STATE_CONTEXT_FOR_PRESET as option.
+/// 
 /// If the plugin implements CLAP_EXT_STATE_CONTEXT then it is mandatory to also implement
 /// CLAP_EXT_STATE.
 
@@ -27,14 +30,18 @@
 extern "C" {
 #endif
 
-static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context.draft/1";
+static CLAP_CONSTEXPR const char CLAP_EXT_STATE_CONTEXT[] = "clap.state-context.draft/2";
 
 enum clap_plugin_state_context_type {
-   // suitable for duplicating a plugin instance
-   CLAP_STATE_CONTEXT_FOR_DUPLICATE = 1,
-
    // suitable for loading a state as a preset
-   CLAP_STATE_CONTEXT_FOR_PRESET = 2,
+   CLAP_STATE_CONTEXT_FOR_PRESET = 1,
+
+  // suitable for duplicating a plugin instance
+   CLAP_STATE_CONTEXT_FOR_DUPLICATE = 2,
+
+   // suitable for loading a state during loading a project/song
+   CLAP_STATE_CONTEXT_FOR_PROJECT = 3,
+
 };
 
 typedef struct clap_plugin_state_context {


### PR DESCRIPTION
the context "loading a project/song" is the most prominent example of using a context information for plugin state persistence. it is also implemented in other audio standards.

I also changed the order of the constants using 1 for the "if in doubt" option.