### PR TITLE
Add CLAP_CONSTEXPR to voice-info and preset-load id declarations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,6 +66,11 @@ Note: we kept the last draft factory ID in order to not break plugins already us
 
 * `clap.h` no longer includes headers from `ext/draft` or `factory/draft`. Draft extension and factory headers must now be explicitly included, either individually or via the `draft.h` header.
 
+## Other changes
+
+* [voice-info.h](include/clap/ext/voice-info.h): Make the voice info id `CLAP_CONSTEXPR` like all other ids
+* [preset-load.h](include/clap/ext/preset-load.h): Make the preset load id and compat id `CLAP_CONSTEXPR` like all other ids
+
 # Changes in 1.1.10
 
 * [params.h](include/clap/ext/params.h): add `CLAP_PARAM_IS_ENUM` flag.

--- a/include/clap/ext/preset-load.h
+++ b/include/clap/ext/preset-load.h
@@ -2,11 +2,11 @@
 
 #include "../plugin.h"
 
-static const char CLAP_EXT_PRESET_LOAD[] = "clap.preset-load/2";
+static CLAP_CONSTEXPR const char CLAP_EXT_PRESET_LOAD[] = "clap.preset-load/2";
 
 // The latest draft is 100% compatible.
 // This compat ID may be removed in 2026.
-static const char CLAP_EXT_PRESET_LOAD_COMPAT[] = "clap.preset-load.draft/2";
+static CLAP_CONSTEXPR const char CLAP_EXT_PRESET_LOAD_COMPAT[] = "clap.preset-load.draft/2";
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/clap/ext/voice-info.h
+++ b/include/clap/ext/voice-info.h
@@ -9,7 +9,7 @@
 // - make the host's voice pool coherent with what the plugin has
 // - turn the host's voice management to mono when the plugin is mono
 
-static const char CLAP_EXT_VOICE_INFO[] = "clap.voice-info";
+static CLAP_CONSTEXPR const char CLAP_EXT_VOICE_INFO[] = "clap.voice-info";
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
To be consistent with all the other extensions