### PR TITLE
Remove unnecessary includes from clap.h

### DIFF
--- a/include/clap/clap.h
+++ b/include/clap/clap.h
@@ -30,11 +30,6 @@
 #include "factory/plugin-factory.h"
 #include "factory/preset-discovery.h"
 
-#include "plugin.h"
-#include "plugin-features.h"
-#include "host.h"
-#include "universal-plugin-id.h"
-
 #include "ext/ambisonic.h"
 #include "ext/audio-ports-activation.h"
 #include "ext/audio-ports-config.h"


### PR DESCRIPTION
let's see if this passes the pull-request workflows... 😉 

I think this removes some clutter. here is my theory:
- `plugin.h` is included via `factory/plugin-factory.h` and plugin extensions (makes sense to me)
  - `host.h` and `plugin-features.h` are included via `plugin.h` (makes sense as well)
- `universal-plugin-id.h` is included via `factory/preset-discovery.h` (where it is actually used)