### PR TITLE
Adjust latency extension requirements

### DIFF
--- a/include/clap/ext/latency.h
+++ b/include/clap/ext/latency.h
@@ -10,15 +10,15 @@ extern "C" {
 
 typedef struct clap_plugin_latency {
    // Returns the plugin latency in samples.
-   // [main-thread & active]
+   // [main-thread & (being-activated | active)]
    uint32_t(CLAP_ABI *get)(const clap_plugin_t *plugin);
 } clap_plugin_latency_t;
 
 typedef struct clap_host_latency {
    // Tell the host that the latency changed.
-   // The latency is only allowed to change if the plugin is deactivated.
+   // The latency is only allowed to change during plugin->activate.
    // If the plugin is activated, call host->request_restart()
-   // [main-thread]
+   // [main-thread & being-activated]
    void(CLAP_ABI *changed)(const clap_host_t *host);
 } clap_host_latency_t;
 


### PR DESCRIPTION
proposal after some discussion on Dischord.

1. Someone reported that Bitwig and Reaper immediately call `plugin_latency->get` after `host_latency->changed` gets called from the plugin during activation
   - solution: allow `plugin_latency->get` to be called already during `plugin->activate`
1. I think it does not make sense if `host_latency->changed` is called before `activate`.
   - solution: require `host_latency->changed` to be called only during `plugin->activate`
   - open question: should it be mandatory for the plugin to call `host_latency->changed` during `activate` after setting up its latency internally? (How do existing hosts handle the case that plugins do not call `host_latency->changed` during activation? Maybe you can tell how Bitwig handles it, @abique?)

Not sure whether the term `being-activated` is optimal. If you have better suggestions, please feel free to change it or suggest something else.