### PR TITLE
undo: split the plugin interface

### DIFF
--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -18,7 +18,7 @@ extern "C" {
 ///
 /// Calling host->undo() or host->redo() is equivalent to clicking undo/redo within the host's GUI.
 ///
-/// If the plugin implements this interface then its undo and redo should be entirely delegated to
+/// If the plugin uses this interface then its undo and redo should be entirely delegated to
 /// the host; clicking in the plugin's UI undo or redo is equivalent to clicking undo or redo in the
 /// host's UI.
 ///
@@ -44,15 +44,11 @@ extern "C" {
 /// and maybe an easier experience for the user because there's a single undo context versus one
 /// for the host and one for each plugin instance.
 ///
-/// The goal for this extension is to make it as easy as possible for the plugin to hook into
-/// the host undo and make it efficient when possible by using deltas.
-///
-/// The plugin interfaces are all optional, and the plugin can for a minimal implementation,
-/// just use the host interface and call host->change_made() without providing a delta.
-/// This is enough for the host to know that it can capture a plugin state for the undo step.
-///
-/// Note: if a plugin is producing a lot of changes within a small amount of time, the host
-/// may merge them into a single undo step.
+/// This extension tries to make it as easy as possible for the plugin to hook into the host undo
+/// and make it efficient when possible by using deltas. The plugin interfaces are all optional, and
+/// the plugin can for a minimal implementation, just use the host interface and call
+/// host->change_made() without providing a delta. This is enough for the host to know that it can
+/// capture a plugin state for the undo step.
 
 typedef struct clap_undo_delta_properties {
    // If false, then all clap_undo_delta_properties's attributes become irrelevant.
@@ -157,6 +153,9 @@ typedef struct clap_host_undo {
    // Note: if the plugin did load a preset or did something that leads to a large delta,
    // it may consider not producing a delta (pass null) and let the host make a state snapshot
    // instead.
+   //
+   // Note: if a plugin is producing a lot of changes within a small amount of time, the host
+   // may merge them into a single undo step.
    //
    // [main-thread]
    void(CLAP_ABI *change_made)(const clap_host_t *host,

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -117,7 +117,7 @@ typedef struct clap_plugin_undo_state {
    // Returns true if the state was correctly restored.
    // [main-thread]
    bool(CLAP_ABI *load)(const clap_plugin_t *plugin, const clap_istream_t *stream);
-} clap_plugin_state_t;
+} clap_plugin_undo_state_t;
 
 // Use CLAP_EXT_UNDO_CONTEXT
 // This is an optional interface, that the plugin can implement in order to know about

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -50,6 +50,9 @@ extern "C" {
 /// The plugin interfaces are all optional, and the plugin can for a minimal implementation,
 /// just use the host interface and call host->change_made() without providing a delta.
 /// This is enough for the host to know that it can capture a plugin state for the undo step.
+///
+/// Note: if a plugin is producing a lot of changes within a small amount of time, the host
+/// may merge them into a single undo step.
 
 typedef struct clap_undo_delta_properties {
    // If false, then all clap_undo_delta_properties's attributes become irrelevant.
@@ -150,6 +153,10 @@ typedef struct clap_host_undo {
    //
    // Note: if the plugin asked for this interface, then host_state->mark_dirty() will not create an
    // implicit undo step.
+   //
+   // Note: if the plugin did load a preset or did something that leads to a large delta,
+   // it may consider not producing a delta (pass null) and let the host make a state snapshot
+   // instead.
    //
    // [main-thread]
    void(CLAP_ABI *change_made)(const clap_host_t *host,

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -3,9 +3,9 @@
 #include "../../plugin.h"
 #include "../../stream.h"
 
-static CLAP_CONSTEXPR const char CLAP_EXT_UNDO[] = "clap.undo/3";
-static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_CONTEXT[] = "clap.undo_context/3";
-static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_DELTA[] = "clap.undo_delta/3";
+static CLAP_CONSTEXPR const char CLAP_EXT_UNDO[] = "clap.undo/4";
+static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_CONTEXT[] = "clap.undo_context/4";
+static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_DELTA[] = "clap.undo_delta/4";
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -6,7 +6,6 @@
 static CLAP_CONSTEXPR const char CLAP_EXT_UNDO[] = "clap.undo/3";
 static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_CONTEXT[] = "clap.undo_context/3";
 static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_DELTA[] = "clap.undo_delta/3";
-static CLAP_CONSTEXPR const char CLAP_EXT_UNDO_STATE[] = "clap.undo_state/3";
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,27 +96,6 @@ typedef struct clap_plugin_undo_delta {
                         const void          *delta,
                         size_t               delta_size);
 } clap_plugin_undo_delta_t;
-
-// Use CLAP_EXT_UNDO_STATE
-// This is an optional interface.
-// When the plugin didn't provide a delta, then the host will perform a plugin state snapshot.
-// This interface should only be implemented if the plugin can provide a lighter state for the undo
-// history.
-// A state saved using this interface must be restored using this interface.
-//
-// TODO: give precise assumptions that can be made by the plugin in order to make its state smaller.
-// TODO: give an example
-typedef struct clap_plugin_undo_state {
-   // Saves the plugin state into stream.
-   // Returns true if the state was correctly saved.
-   // [main-thread]
-   bool(CLAP_ABI *save)(const clap_plugin_t *plugin, const clap_ostream_t *stream);
-
-   // Loads the plugin state from stream.
-   // Returns true if the state was correctly restored.
-   // [main-thread]
-   bool(CLAP_ABI *load)(const clap_plugin_t *plugin, const clap_istream_t *stream);
-} clap_plugin_undo_state_t;
 
 // Use CLAP_EXT_UNDO_CONTEXT
 // This is an optional interface, that the plugin can implement in order to know about

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -108,7 +108,7 @@ typedef struct clap_plugin_undo_context {
    void(CLAP_ABI *set_can_redo)(const clap_plugin_t *plugin, bool can_redo);
 
    // Sets the name of the next undo or redo step.
-   // name: null terminated string if an redo/undo step exists, null otherwise.
+   // name: null terminated string.
    // [main-thread]
    void(CLAP_ABI *set_undo_name)(const clap_plugin_t *plugin, const char *name);
    void(CLAP_ABI *set_redo_name)(const clap_plugin_t *plugin, const char *name);


### PR DESCRIPTION
There's two plugin interfaces which both are optional.

A super minimal implementation for the plugin is to just query the host interface, and call change_made() with a null delta. This lets the host know that a change was made, snapshot the plugin state and workout the undo/redo by using state save/load.

Then the two plugin interfaces are:
- delta: optimization
- context: user interface