### PR TITLE
Add a description of the expectation of request_callback timing

### DIFF
--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -39,7 +39,7 @@ typedef struct clap_host {
    // available main thread time slice. Typically callbacks occur withink 33ms / 30hz.
    // Despite this guidance, plugins should not make assumptions about the exactness of timing for
    // a main thread callback, but hosts should endeavour to be prompt. For example, in high load situations
-   // the host may starve the gui/main thread in favor of audio processing, leading to substantially
+   // the environment may starve the gui/main thread in favor of audio processing, leading to substantially
    // longer latencies for the callback than the indicative times given here.
    // [thread-safe]
    void(CLAP_ABI *request_callback)(const struct clap_host *host);

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -36,9 +36,9 @@ typedef struct clap_host {
 
    // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
    // This callback should be called as soon as practicable, usually in the host application's next
-   // available main thread time slice. Typically callbacks occur at least in the 10s-to-50s-of-milliseconds
-   // or 30-120hz timeslice range. Plugins should not make assumptions about the exactness of timing for
-   // a main thread callback but hosts should endeavour to be prompt. However in high load situations
+   // available main thread time slice. Typically callbacks occur withink 33ms / 30hz.
+   // Despite this guidance, plugins should not make assumptions about the exactness of timing for
+   // a main thread callback, but hosts should endeavour to be prompt. For example, in high load situations
    // the host may starve the gui/main thread in favor of audio processing, leading to substantially
    // longer latencies for the callback than the indicative times given here.
    // [thread-safe]

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -35,6 +35,10 @@ typedef struct clap_host {
    void(CLAP_ABI *request_process)(const struct clap_host *host);
 
    // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
+   // This callback should be called as soon as practicable, usually in the host applications next
+   // available main thread time slice. Typically callbacks occur at least in the 10s-to-50s-of-milliseconds
+   // or 30-120hz timeslice range. Plugins should not make assumptions about the exactness of timing for
+   // a main thread callback but hosts should endeavour to be prompt.
    // [thread-safe]
    void(CLAP_ABI *request_callback)(const struct clap_host *host);
 } clap_host_t;

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -38,7 +38,9 @@ typedef struct clap_host {
    // This callback should be called as soon as practicable, usually in the host application's next
    // available main thread time slice. Typically callbacks occur at least in the 10s-to-50s-of-milliseconds
    // or 30-120hz timeslice range. Plugins should not make assumptions about the exactness of timing for
-   // a main thread callback but hosts should endeavour to be prompt.
+   // a main thread callback but hosts should endeavour to be prompt. However in high load situations
+   // the host may starve the gui/main thread in favor of audio processing, leading to substantially
+   // longer latencies for the callback than the indicative times given here.
    // [thread-safe]
    void(CLAP_ABI *request_callback)(const struct clap_host *host);
 } clap_host_t;

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -35,7 +35,7 @@ typedef struct clap_host {
    void(CLAP_ABI *request_process)(const struct clap_host *host);
 
    // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
-   // This callback should be called as soon as practicable, usually in the host applications next
+   // This callback should be called as soon as practicable, usually in the host application's next
    // available main thread time slice. Typically callbacks occur at least in the 10s-to-50s-of-milliseconds
    // or 30-120hz timeslice range. Plugins should not make assumptions about the exactness of timing for
    // a main thread callback but hosts should endeavour to be prompt.


### PR DESCRIPTION
Without making a requirement, indicate the intent of the timing.