### PR TITLE
Fix abort on delete plugin from track FX.

### DIFF
--- a/src/plugin-template.c
+++ b/src/plugin-template.c
@@ -419,7 +419,7 @@ static void entry_deinit_guard(void) {
 #endif
 
    const int cnt = --g_entry_init_counter;
-   assert(cnt > 0);
+   assert(cnt >= 0);
 
    bool succeed = true;
    if (cnt == 0)


### PR DESCRIPTION
The plugin-template.c example plugin code will crash Reaper when you delete it from the track FX because of the assertion made on line 422. This can be fixed by simply changing the inequality.