### PR TITLE
Remove comment stating that thread-safe methods must also be realtime-safe

### DIFF
--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -52,9 +52,7 @@ extern "C" {
 ///
 ///  Clap also tags some functions as [thread-safe]. Functions tagged as [thread-safe] can be called
 ///  from any thread unless explicitly counter-indicated (for instance [thread-safe, !audio-thread])
-///  and may be called concurrently. Since a [thread-safe] function may be called from the
-///  [audio-thread] unless explicitly counter-indicated, it must also meet the realtime constraints
-///  as describes above.
+///  and may be called concurrently.
 
 // This interface is useful to do runtime checks and make
 // sure that the functions are called on the correct threads.


### PR DESCRIPTION
I don't think this comment makes a whole lot of sense given the set of existing functions in the CLAP API which are marked `[thread-safe]`. For instance:

- `clap_plugin_entry`: `get_factory`
- `clap_host_gui`: `resize_hints_changed`, `request_resize`, `request_show`, `request_hide`, `closed`
- `clap_plugin_factory`: `get_plugin_count`, `get_plugin_descriptor`, `create_plugin`
- `clap_preset_discovery_factory`: `count`, `get_descriptor`, `create`

Ultimately, thread safety and real-time safety are simply different concerns, and any given function can satisfy one, both or neither. E.g., `std::mutex::lock` is thread-safe but not realtime-safe, and `clap_plugin.process` is realtime-safe but not thread-safe. I would support the idea of introducing a separate `[realtime-safe]` annotation, but it doesn't make sense for it to be conflated with `[thread-safe]`.