### PR TITLE
Add missing surround sound identifiers

### DIFF
--- a/include/clap/ext/surround.h
+++ b/include/clap/ext/surround.h
@@ -55,6 +55,8 @@ enum {
    CLAP_SURROUND_TBL = 15, // Rear Left Height
    CLAP_SURROUND_TBC = 16, // Rear Center Height
    CLAP_SURROUND_TBR = 17, // Rear Right Height
+   CLAP_SURROUND_TSL = 18, // Side Left Height
+   CLAP_SURROUND_TSR = 19, // Side Right Height
 };
 
 typedef struct clap_plugin_surround {

--- a/include/clap/ext/surround.h
+++ b/include/clap/ext/surround.h
@@ -41,11 +41,11 @@ enum {
    CLAP_SURROUND_FR = 1,   // Front Right
    CLAP_SURROUND_FC = 2,   // Front Center
    CLAP_SURROUND_LFE = 3,  // Low Frequency
-   CLAP_SURROUND_BL = 4,   // Back Left
-   CLAP_SURROUND_BR = 5,   // Back Right
+   CLAP_SURROUND_BL = 4,   // Back (Rear) Left
+   CLAP_SURROUND_BR = 5,   // Back (Rear) Right
    CLAP_SURROUND_FLC = 6,  // Front Left of Center
    CLAP_SURROUND_FRC = 7,  // Front Right of Center
-   CLAP_SURROUND_BC = 8,   // Back Center
+   CLAP_SURROUND_BC = 8,   // Back (Rear) Center
    CLAP_SURROUND_SL = 9,   // Side Left
    CLAP_SURROUND_SR = 10,  // Side Right
    CLAP_SURROUND_TC = 11,  // Top (Height) Center

--- a/include/clap/ext/surround.h
+++ b/include/clap/ext/surround.h
@@ -48,15 +48,15 @@ enum {
    CLAP_SURROUND_BC = 8,   // Back Center
    CLAP_SURROUND_SL = 9,   // Side Left
    CLAP_SURROUND_SR = 10,  // Side Right
-   CLAP_SURROUND_TC = 11,  // Top Center
-   CLAP_SURROUND_TFL = 12, // Front Left Height
-   CLAP_SURROUND_TFC = 13, // Front Center Height
-   CLAP_SURROUND_TFR = 14, // Front Right Height
-   CLAP_SURROUND_TBL = 15, // Rear Left Height
-   CLAP_SURROUND_TBC = 16, // Rear Center Height
-   CLAP_SURROUND_TBR = 17, // Rear Right Height
-   CLAP_SURROUND_TSL = 18, // Side Left Height
-   CLAP_SURROUND_TSR = 19, // Side Right Height
+   CLAP_SURROUND_TC = 11,  // Top (Height) Center
+   CLAP_SURROUND_TFL = 12, // Top (Height) Front Left
+   CLAP_SURROUND_TFC = 13, // Top (Height) Front Center
+   CLAP_SURROUND_TFR = 14, // Top (Height) Front Right
+   CLAP_SURROUND_TBL = 15, // Top (Height) Back (Rear) Left
+   CLAP_SURROUND_TBC = 16, // Top (Height) Back (Rear) Center
+   CLAP_SURROUND_TBR = 17, // Top (Height) Back (Rear) Right
+   CLAP_SURROUND_TSL = 18, // Top (Height) Side Left
+   CLAP_SURROUND_TSR = 19, // Top (Height) Side Right
 };
 
 typedef struct clap_plugin_surround {


### PR DESCRIPTION
This PR adds two missing surround sound identifiers: "Side Left Height" (or top middle left) and "Side Right Height" (or top middle right) as seen in the [Dolby 7.1.6 specification](https://www.dolby.com/about/support/guide/speaker-setup-guides/7.1.6-overhead-speaker-setup-guide/) which was mentioned in #407.

"Top Center" (`CLAP_SURROUND_TC`) already exists so I don't think a 3rd identifier is needed.
This addition should be backwards compatible.

As a disclaimer, I do not know anything about surround sound, so someone familiar with it should look over this PR.

Closes #407