### PR TITLE
Ignore Meson Generated Files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ cmake-build*/
 ignore/*
 
 .DS_Store
+
+# Meson
+.meson-subproject*
+


### PR DESCRIPTION
When using a cmake project as a [meson](https://mesonbuild.com) subproject, meson generates `meson-subproject*.*` files.  This change ignores them.