### PR TITLE
Webview extension

### DIFF
--- a/include/clap/all.h
+++ b/include/clap/all.h
@@ -15,4 +15,4 @@
 #include "ext/draft/triggers.h"
 #include "ext/draft/tuning.h"
 #include "ext/draft/undo.h"
-#include "ext/draft/web.h"
+#include "ext/draft/webview.h"

--- a/include/clap/all.h
+++ b/include/clap/all.h
@@ -15,3 +15,4 @@
 #include "ext/draft/triggers.h"
 #include "ext/draft/tuning.h"
 #include "ext/draft/undo.h"
+#include "ext/draft/web.h"

--- a/include/clap/ext/draft/web.h
+++ b/include/clap/ext/draft/web.h
@@ -17,9 +17,10 @@ extern "C" {
 
 typedef struct clap_plugin_web {
    // Returns the URL for the webview's initial navigation, as a null-terminated UTF-8 string.
-   // If this URL is relative, it is resolved relative to the plugin (bundle) directory, and
-   // cannot be outside it.  The host may use any protocol to serve this content, and the page
-   // must not assume that the root of the domain is the root of the bundle. The URL may also be
+   // If this URL is relative, it is resolved relative to the plugin (bundle) resource directory.
+   // The host may assume that no resources outside of that directory are used, and may use any
+   // protocol to provide this content, following HTTP-like relative URL resolution. The page must
+   // not assume that the root path of the domain is the root of the bundle. The URL may also be
    // absolute, including a `file://` URL.
    // Returns true on success.
    // [main-thread]

--- a/include/clap/ext/draft/web.h
+++ b/include/clap/ext/draft/web.h
@@ -1,0 +1,52 @@
+#pragma once
+
+static CLAP_CONSTEXPR const char CLAP_EXT_WEB[] = "clap.web/1";
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// @page Web
+///
+/// This extension enables the plugin to provide the start-page for a webview UI, and exchange
+/// messages back and forth.
+///
+/// Messages are received in the webview using a standard MessageEvent, with the data in an
+/// ArrayBuffer. They are posted back to the plugin using window.parent.postMessage(), with the
+/// data in an ArrayBuffer or TypedArray.
+
+typedef struct clap_plugin_web {
+   // Returns the URL for the webview's initial navigation, as a null-terminated UTF-8 string.
+   // If this URL is relative, it is resolved relative to the plugin (bundle) directory, and
+   // cannot be outside it.  The host may use any protocol to serve this content, and the page
+   // must not assume that the root of the domain is the root of the bundle. The URL may also be
+   // absolute, including a `file://` URL.
+   // Returns true on success.
+   // [main-thread]
+   bool(CLAP_ABI *get_start)(const clap_plugin_t *plugin,
+                             char                *out_buffer,
+                             uint32_t            out_buffer_capacity);
+
+   // Receives a single message from the webview.
+   // Returns true on success.
+   // [main-thread]
+   bool(CLAP_ABI *receive)(const clap_plugin_t *plugin, const void *buffer, uint32_t size);
+
+} clap_plugin_web_t;
+
+typedef struct clap_host_web {
+   // Checks whether the webview is open (and ready to receive messages)
+   // [thread-safe]
+   bool(CLAP_ABI *is_open)(const clap_host_t *host);
+
+   // Sends a single message to the webview.
+   // It must not allocate or block if called from the audio thread.
+   // Returns true on success.
+   // [thread-safe]
+   bool(CLAP_ABI *send)(const clap_host_t *host, const void *buffer, uint32_t size);
+
+} clap_host_web_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/clap/ext/draft/webview.h
+++ b/include/clap/ext/draft/webview.h
@@ -1,12 +1,12 @@
 #pragma once
 
-static CLAP_CONSTEXPR const char CLAP_EXT_WEB[] = "clap.web/1";
+static CLAP_CONSTEXPR const char CLAP_EXT_WEBVIEW[] = "clap.webview/1";
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/// @page Web
+/// @page Webview
 ///
 /// This extension enables the plugin to provide the start-page for a webview UI, and exchange
 /// messages back and forth.
@@ -15,7 +15,7 @@ extern "C" {
 /// ArrayBuffer. They are posted back to the plugin using window.parent.postMessage(), with the
 /// data in an ArrayBuffer or TypedArray.
 
-typedef struct clap_plugin_web {
+typedef struct clap_plugin_webview {
    // Returns the URL for the webview's initial navigation, as a null-terminated UTF-8 string.
    // If this URL is relative, it is resolved relative to the plugin (bundle) resource directory.
    // The host may assume that no resources outside of that directory are used, and may use any
@@ -33,9 +33,9 @@ typedef struct clap_plugin_web {
    // [main-thread]
    bool(CLAP_ABI *receive)(const clap_plugin_t *plugin, const void *buffer, uint32_t size);
 
-} clap_plugin_web_t;
+} clap_plugin_webview_t;
 
-typedef struct clap_host_web {
+typedef struct clap_host_webview {
    // Checks whether the webview is open (and ready to receive messages)
    // [thread-safe]
    bool(CLAP_ABI *is_open)(const clap_host_t *host);
@@ -46,7 +46,7 @@ typedef struct clap_host_web {
    // [thread-safe]
    bool(CLAP_ABI *send)(const clap_host_t *host, const void *buffer, uint32_t size);
 
-} clap_host_web_t;
+} clap_host_webview_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This draft lets CLAP plugins straightforwardly use a web-page for their UI.

Messages are exchanged in both directions as opaque blocks of bytes on the main thread.  The webpage receives and sends messages using standard web APIs.