### PR TITLE
Add standard header guards alongside #pragma once

### DIFF
--- a/include/clap/all.h
+++ b/include/clap/all.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_ALL_H
+#define CLAP_ALL_H
 
 #include "clap.h"
 
@@ -16,3 +18,5 @@
 #include "ext/draft/tuning.h"
 #include "ext/draft/undo.h"
 #include "ext/draft/webview.h"
+
+#endif // CLAP_ALL_H

--- a/include/clap/audio-buffer.h
+++ b/include/clap/audio-buffer.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_AUDIO_BUFFER_H
+#define CLAP_AUDIO_BUFFER_H
 
 #include "private/std.h"
 
@@ -35,3 +37,4 @@ typedef struct clap_audio_buffer {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_AUDIO_BUFFER_H

--- a/include/clap/clap.h
+++ b/include/clap/clap.h
@@ -24,6 +24,8 @@
  */
 
 #pragma once
+#ifndef CLAP_CLAP_H
+#define CLAP_CLAP_H
 
 #include "entry.h"
 
@@ -62,3 +64,5 @@
 #include "ext/timer-support.h"
 #include "ext/track-info.h"
 #include "ext/voice-info.h"
+
+#endif // CLAP_CLAP_H

--- a/include/clap/color.h
+++ b/include/clap/color.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_COLOR_H
+#define CLAP_COLOR_H
 
 #include "private/std.h"
 
@@ -18,3 +20,4 @@ static const CLAP_CONSTEXPR clap_color_t CLAP_COLOR_TRANSPARENT = { 0, 0, 0, 0 }
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_COLOR_H

--- a/include/clap/entry.h
+++ b/include/clap/entry.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_ENTRY_H
+#define CLAP_ENTRY_H
 
 #include "version.h"
 #include "private/macros.h"
@@ -134,3 +136,4 @@ CLAP_EXPORT extern const clap_plugin_entry_t clap_entry;
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_ENTRY_H

--- a/include/clap/events.h
+++ b/include/clap/events.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EVENTS_H
+#define CLAP_EVENTS_H
 
 #include "private/std.h"
 #include "fixedpoint.h"
@@ -365,3 +367,4 @@ typedef struct clap_output_events {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EVENTS_H

--- a/include/clap/ext/ambisonic.h
+++ b/include/clap/ext/ambisonic.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_AMBISONIC_H
+#define CLAP_EXT_AMBISONIC_H
 
 #include "../plugin.h"
 
@@ -61,3 +63,4 @@ typedef struct clap_host_ambisonic {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_AMBISONIC_H

--- a/include/clap/ext/audio-ports-activation.h
+++ b/include/clap/ext/audio-ports-activation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_AUDIO_PORTS_ACTIVATION_H
+#define CLAP_EXT_AUDIO_PORTS_ACTIVATION_H
 
 #include "../plugin.h"
 
@@ -62,3 +64,4 @@ typedef struct clap_plugin_audio_ports_activation {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_AUDIO_PORTS_ACTIVATION_H

--- a/include/clap/ext/audio-ports-config.h
+++ b/include/clap/ext/audio-ports-config.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_AUDIO_PORTS_CONFIG_H
+#define CLAP_EXT_AUDIO_PORTS_CONFIG_H
 
 #include "../string-sizes.h"
 #include "../plugin.h"
@@ -107,3 +109,4 @@ typedef struct clap_host_audio_ports_config {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_AUDIO_PORTS_CONFIG_H

--- a/include/clap/ext/audio-ports.h
+++ b/include/clap/ext/audio-ports.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_AUDIO_PORTS_H
+#define CLAP_EXT_AUDIO_PORTS_H
 
 #include "../plugin.h"
 #include "../string-sizes.h"
@@ -114,3 +116,4 @@ typedef struct clap_host_audio_ports {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_AUDIO_PORTS_H

--- a/include/clap/ext/configurable-audio-ports.h
+++ b/include/clap/ext/configurable-audio-ports.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_CONFIGURABLE_AUDIO_PORTS_H
+#define CLAP_EXT_CONFIGURABLE_AUDIO_PORTS_H
 
 #include "audio-ports.h"
 
@@ -61,3 +63,4 @@ typedef struct clap_plugin_configurable_audio_ports {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_CONFIGURABLE_AUDIO_PORTS_H

--- a/include/clap/ext/context-menu.h
+++ b/include/clap/ext/context-menu.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_CONTEXT_MENU_H
+#define CLAP_EXT_CONTEXT_MENU_H
 
 #include "../plugin.h"
 
@@ -165,3 +167,4 @@ typedef struct clap_host_context_menu {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_CONTEXT_MENU_H

--- a/include/clap/ext/draft/extensible-audio-ports.h
+++ b/include/clap/ext/draft/extensible-audio-ports.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_EXTENSIBLE_AUDIO_PORTS_H
+#define CLAP_EXT_EXTENSIBLE_AUDIO_PORTS_H
 
 #include "../audio-ports.h"
 
@@ -31,3 +33,4 @@ typedef struct clap_plugin_extensible_audio_ports {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_EXTENSIBLE_AUDIO_PORTS_H

--- a/include/clap/ext/draft/gain-adjustment-metering.h
+++ b/include/clap/ext/draft/gain-adjustment-metering.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_GAIN_ADJUSTMENT_METERING_H
+#define CLAP_EXT_GAIN_ADJUSTMENT_METERING_H
 
 #include "../../plugin.h"
 
@@ -32,3 +34,4 @@ typedef struct clap_plugin_gain_adjustment_metering {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_GAIN_ADJUSTMENT_METERING_H

--- a/include/clap/ext/draft/mini-curve-display.h
+++ b/include/clap/ext/draft/mini-curve-display.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_MINI_CURVE_DISPLAY_H
+#define CLAP_EXT_MINI_CURVE_DISPLAY_H
 
 #include "../../plugin.h"
 
@@ -151,3 +153,4 @@ typedef struct clap_host_mini_curve_display {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_MINI_CURVE_DISPLAY_H

--- a/include/clap/ext/draft/project-location.h
+++ b/include/clap/ext/draft/project-location.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_PROJECT_LOCATION_H
+#define CLAP_EXT_PROJECT_LOCATION_H
 
 #include "../../color.h"
 #include "../../plugin.h"
@@ -106,3 +108,4 @@ typedef struct clap_plugin_project_location {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_PROJECT_LOCATION_H

--- a/include/clap/ext/draft/resource-directory.h
+++ b/include/clap/ext/draft/resource-directory.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_RESOURCE_DIRECTORY_H
+#define CLAP_EXT_RESOURCE_DIRECTORY_H
 
 #include "../../plugin.h"
 
@@ -86,3 +88,4 @@ typedef struct clap_host_resource_directory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_RESOURCE_DIRECTORY_H

--- a/include/clap/ext/draft/scratch-memory.h
+++ b/include/clap/ext/draft/scratch-memory.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_SCRATCH_MEMORY_H
+#define CLAP_EXT_SCRATCH_MEMORY_H
 
 #include "../../plugin.h"
 
@@ -88,3 +90,4 @@ typedef struct clap_host_scratch_memory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_SCRATCH_MEMORY_H

--- a/include/clap/ext/draft/transport-control.h
+++ b/include/clap/ext/draft/transport-control.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TRANSPORT_CONTROL_H
+#define CLAP_EXT_TRANSPORT_CONTROL_H
 
 #include "../../plugin.h"
 
@@ -64,3 +66,4 @@ typedef struct clap_host_transport_control {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TRANSPORT_CONTROL_H

--- a/include/clap/ext/draft/triggers.h
+++ b/include/clap/ext/draft/triggers.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TRIGGERS_H
+#define CLAP_EXT_TRIGGERS_H
 
 #include "../../plugin.h"
 #include "../../events.h"
@@ -142,3 +144,4 @@ typedef struct clap_host_triggers {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TRIGGERS_H

--- a/include/clap/ext/draft/tuning.h
+++ b/include/clap/ext/draft/tuning.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TUNING_H
+#define CLAP_EXT_TUNING_H
 
 #include "../../plugin.h"
 #include "../../events.h"
@@ -74,3 +76,4 @@ typedef struct clap_host_tuning {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TUNING_H

--- a/include/clap/ext/draft/undo.h
+++ b/include/clap/ext/draft/undo.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_UNDO_H
+#define CLAP_EXT_UNDO_H
 
 #include "../../plugin.h"
 #include "../../stream.h"
@@ -199,3 +201,4 @@ typedef struct clap_host_undo {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_UNDO_H

--- a/include/clap/ext/draft/webview.h
+++ b/include/clap/ext/draft/webview.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_WEBVIEW_H
+#define CLAP_EXT_WEBVIEW_H
 
 #include "../../plugin.h"
 #include "../../stream.h"
@@ -75,3 +77,4 @@ typedef struct clap_host_webview {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_WEBVIEW_H

--- a/include/clap/ext/event-registry.h
+++ b/include/clap/ext/event-registry.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_EVENT_REGISTRY_H
+#define CLAP_EXT_EVENT_REGISTRY_H
 
 #include "../plugin.h"
 
@@ -20,3 +22,4 @@ typedef struct clap_host_event_registry {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_EVENT_REGISTRY_H

--- a/include/clap/ext/gui.h
+++ b/include/clap/ext/gui.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_GUI_H
+#define CLAP_EXT_GUI_H
 
 #include "../plugin.h"
 
@@ -242,3 +244,4 @@ typedef struct clap_host_gui {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_GUI_H

--- a/include/clap/ext/latency.h
+++ b/include/clap/ext/latency.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_LATENCY_H
+#define CLAP_EXT_LATENCY_H
 
 #include "../plugin.h"
 
@@ -25,3 +27,4 @@ typedef struct clap_host_latency {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_LATENCY_H

--- a/include/clap/ext/log.h
+++ b/include/clap/ext/log.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_LOG_H
+#define CLAP_EXT_LOG_H
 
 #include "../plugin.h"
 
@@ -31,3 +33,4 @@ typedef struct clap_host_log {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_LOG_H

--- a/include/clap/ext/note-name.h
+++ b/include/clap/ext/note-name.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_NOTE_NAME_H
+#define CLAP_EXT_NOTE_NAME_H
 
 #include "../plugin.h"
 #include "../string-sizes.h"
@@ -35,3 +37,4 @@ typedef struct clap_host_note_name {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_NOTE_NAME_H

--- a/include/clap/ext/note-ports.h
+++ b/include/clap/ext/note-ports.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_NOTE_PORTS_H
+#define CLAP_EXT_NOTE_PORTS_H
 
 #include "../plugin.h"
 #include "../string-sizes.h"
@@ -77,3 +79,4 @@ typedef struct clap_host_note_ports {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_NOTE_PORTS_H

--- a/include/clap/ext/param-indication.h
+++ b/include/clap/ext/param-indication.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_PARAM_INDICATION_H
+#define CLAP_EXT_PARAM_INDICATION_H
 
 #include "params.h"
 #include "../color.h"
@@ -75,3 +77,4 @@ typedef struct clap_plugin_param_indication {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_PARAM_INDICATION_H

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_PARAMS_H
+#define CLAP_EXT_PARAMS_H
 
 #include "../plugin.h"
 #include "../string-sizes.h"
@@ -380,3 +382,4 @@ typedef struct clap_host_params {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_PARAMS_H

--- a/include/clap/ext/posix-fd-support.h
+++ b/include/clap/ext/posix-fd-support.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_POSIX_FD_SUPPORT_H
+#define CLAP_EXT_POSIX_FD_SUPPORT_H
 
 #include "../plugin.h"
 
@@ -47,3 +49,4 @@ typedef struct clap_host_posix_fd_support {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_POSIX_FD_SUPPORT_H

--- a/include/clap/ext/preset-load.h
+++ b/include/clap/ext/preset-load.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_PRESET_LOAD_H
+#define CLAP_EXT_PRESET_LOAD_H
 
 #include "../plugin.h"
 
@@ -51,3 +53,4 @@ typedef struct clap_host_preset_load {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_PRESET_LOAD_H

--- a/include/clap/ext/remote-controls.h
+++ b/include/clap/ext/remote-controls.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_REMOTE_CONTROLS_H
+#define CLAP_EXT_REMOTE_CONTROLS_H
 
 #include "../plugin.h"
 #include "../string-sizes.h"
@@ -81,3 +83,4 @@ typedef struct clap_host_remote_controls {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_REMOTE_CONTROLS_H

--- a/include/clap/ext/render.h
+++ b/include/clap/ext/render.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_RENDER_H
+#define CLAP_EXT_RENDER_H
 
 #include "../plugin.h"
 
@@ -37,3 +39,4 @@ typedef struct clap_plugin_render {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_RENDER_H

--- a/include/clap/ext/state-context.h
+++ b/include/clap/ext/state-context.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_STATE_CONTEXT_H
+#define CLAP_EXT_STATE_CONTEXT_H
 
 #include "../plugin.h"
 #include "../stream.h"
@@ -70,3 +72,4 @@ typedef struct clap_plugin_state_context {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_STATE_CONTEXT_H

--- a/include/clap/ext/state.h
+++ b/include/clap/ext/state.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_STATE_H
+#define CLAP_EXT_STATE_H
 
 #include "../plugin.h"
 #include "../stream.h"
@@ -43,3 +45,4 @@ typedef struct clap_host_state {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_STATE_H

--- a/include/clap/ext/surround.h
+++ b/include/clap/ext/surround.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_SURROUND_H
+#define CLAP_EXT_SURROUND_H
 
 #include "../plugin.h"
 
@@ -87,3 +89,4 @@ typedef struct clap_host_surround {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_SURROUND_H

--- a/include/clap/ext/tail.h
+++ b/include/clap/ext/tail.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TAIL_H
+#define CLAP_EXT_TAIL_H
 
 #include "../plugin.h"
 
@@ -24,3 +26,4 @@ typedef struct clap_host_tail {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TAIL_H

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_THREAD_CHECK_H
+#define CLAP_EXT_THREAD_CHECK_H
 
 #include "../plugin.h"
 
@@ -70,3 +72,4 @@ typedef struct clap_host_thread_check {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_THREAD_CHECK_H

--- a/include/clap/ext/thread-pool.h
+++ b/include/clap/ext/thread-pool.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_THREAD_POOL_H
+#define CLAP_EXT_THREAD_POOL_H
 
 #include "../plugin.h"
 
@@ -64,3 +66,4 @@ typedef struct clap_host_thread_pool {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_THREAD_POOL_H

--- a/include/clap/ext/timer-support.h
+++ b/include/clap/ext/timer-support.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TIMER_SUPPORT_H
+#define CLAP_EXT_TIMER_SUPPORT_H
 
 #include "../plugin.h"
 
@@ -29,3 +31,4 @@ typedef struct clap_host_timer_support {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TIMER_SUPPORT_H

--- a/include/clap/ext/track-info.h
+++ b/include/clap/ext/track-info.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_TRACK_INFO_H
+#define CLAP_EXT_TRACK_INFO_H
 
 #include "../plugin.h"
 #include "../color.h"
@@ -64,3 +66,4 @@ typedef struct clap_host_track_info {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_TRACK_INFO_H

--- a/include/clap/ext/voice-info.h
+++ b/include/clap/ext/voice-info.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_EXT_VOICE_INFO_H
+#define CLAP_EXT_VOICE_INFO_H
 
 #include "../plugin.h"
 
@@ -54,3 +56,4 @@ typedef struct clap_host_voice_info {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_EXT_VOICE_INFO_H

--- a/include/clap/factory/draft/plugin-invalidation.h
+++ b/include/clap/factory/draft/plugin-invalidation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PLUGIN_INVALIDATION_H
+#define CLAP_PLUGIN_INVALIDATION_H
 
 #include "../../private/std.h"
 #include "../../private/macros.h"
@@ -45,3 +47,4 @@ typedef struct clap_plugin_invalidation_factory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PLUGIN_INVALIDATION_H

--- a/include/clap/factory/draft/plugin-state-converter.h
+++ b/include/clap/factory/draft/plugin-state-converter.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PLUGIN_STATE_CONVERTER_H
+#define CLAP_PLUGIN_STATE_CONVERTER_H
 
 #include "../../id.h"
 #include "../../universal-plugin-id.h"
@@ -97,3 +99,4 @@ typedef struct clap_plugin_state_converter_factory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PLUGIN_STATE_CONVERTER_H

--- a/include/clap/factory/plugin-factory.h
+++ b/include/clap/factory/plugin-factory.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PLUGIN_FACTORY_H
+#define CLAP_PLUGIN_FACTORY_H
 
 #include "../plugin.h"
 
@@ -40,3 +42,4 @@ typedef struct clap_plugin_factory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PLUGIN_FACTORY_H

--- a/include/clap/factory/preset-discovery.h
+++ b/include/clap/factory/preset-discovery.h
@@ -40,6 +40,8 @@
 */
 
 #pragma once
+#ifndef CLAP_PRESET_DISCOVERY_H
+#define CLAP_PRESET_DISCOVERY_H
 
 #include "../private/std.h"
 #include "../private/macros.h"
@@ -311,3 +313,4 @@ typedef struct clap_preset_discovery_factory {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PRESET_DISCOVERY_H

--- a/include/clap/fixedpoint.h
+++ b/include/clap/fixedpoint.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_FIXEDPOINT_H
+#define CLAP_FIXEDPOINT_H
 
 #include "private/std.h"
 #include "private/macros.h"
@@ -14,3 +16,4 @@ static const CLAP_CONSTEXPR int64_t CLAP_SECTIME_FACTOR = 1LL << 31;
 
 typedef int64_t clap_beattime;
 typedef int64_t clap_sectime;
+#endif // CLAP_FIXEDPOINT_H

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_HOST_H
+#define CLAP_HOST_H
 
 #include "version.h"
 
@@ -49,3 +51,4 @@ typedef struct clap_host {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_HOST_H

--- a/include/clap/id.h
+++ b/include/clap/id.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_ID_H
+#define CLAP_ID_H
 
 #include "private/std.h"
 #include "private/macros.h"
@@ -6,3 +8,4 @@
 typedef uint32_t clap_id;
 
 static const CLAP_CONSTEXPR clap_id CLAP_INVALID_ID = UINT32_MAX;
+#endif // CLAP_ID_H

--- a/include/clap/plugin-features.h
+++ b/include/clap/plugin-features.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PLUGIN_FEATURES_H
+#define CLAP_PLUGIN_FEATURES_H
 
 // This file provides a set of standard plugin features meant to be used
 // within clap_plugin_descriptor.features.
@@ -77,3 +79,4 @@
 #define CLAP_PLUGIN_FEATURE_STEREO "stereo"
 #define CLAP_PLUGIN_FEATURE_SURROUND "surround"
 #define CLAP_PLUGIN_FEATURE_AMBISONIC "ambisonic"
+#endif // CLAP_PLUGIN_FEATURES_H

--- a/include/clap/plugin.h
+++ b/include/clap/plugin.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PLUGIN_H
+#define CLAP_PLUGIN_H
 
 #include "private/macros.h"
 #include "host.h"
@@ -112,3 +114,4 @@ typedef struct clap_plugin {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PLUGIN_H

--- a/include/clap/private/macros.h
+++ b/include/clap/private/macros.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PRIVATE_MACROS_H
+#define CLAP_PRIVATE_MACROS_H
 
 // Define CLAP_EXPORT
 #if !defined(CLAP_EXPORT)
@@ -48,3 +50,4 @@
 #if defined(CLAP_CPLUSPLUS) && CLAP_CPLUSPLUS >= 202002L
 #   define CLAP_HAS_CXX20
 #endif
+#endif // CLAP_PRIVATE_MACROS_H

--- a/include/clap/private/std.h
+++ b/include/clap/private/std.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PRIVATE_STD_H
+#define CLAP_PRIVATE_STD_H
 
 #include "macros.h"
 
@@ -14,3 +16,4 @@
 #   include <stddef.h>
 #   include <stdbool.h>
 #endif
+#endif // CLAP_PRIVATE_STD_H

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_PROCESS_H
+#define CLAP_PROCESS_H
 
 #include "events.h"
 #include "audio-buffer.h"
@@ -64,3 +66,4 @@ typedef struct clap_process {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_PROCESS_H

--- a/include/clap/stream.h
+++ b/include/clap/stream.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_STREAM_H
+#define CLAP_STREAM_H
 
 #include "private/std.h"
 #include "private/macros.h"
@@ -36,3 +38,4 @@ typedef struct clap_ostream {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_STREAM_H

--- a/include/clap/string-sizes.h
+++ b/include/clap/string-sizes.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_STRING_SIZES_H
+#define CLAP_STRING_SIZES_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,3 +21,4 @@ enum {
 #ifdef __cplusplus
 }
 #endif
+#endif // CLAP_STRING_SIZES_H

--- a/include/clap/timestamp.h
+++ b/include/clap/timestamp.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_TIMESTAMP_H
+#define CLAP_TIMESTAMP_H
 
 #include "private/std.h"
 #include "private/macros.h"
@@ -9,3 +11,4 @@ typedef uint64_t clap_timestamp;
 
 // Value for unknown timestamp.
 static const CLAP_CONSTEXPR clap_timestamp CLAP_TIMESTAMP_UNKNOWN = 0;
+#endif // CLAP_TIMESTAMP_H

--- a/include/clap/universal-plugin-id.h
+++ b/include/clap/universal-plugin-id.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_UNIVERSAL_PLUGIN_ID_H
+#define CLAP_UNIVERSAL_PLUGIN_ID_H
 
 // Pair of plugin ABI and plugin identifier.
 //
@@ -24,3 +26,4 @@ typedef struct clap_universal_plugin_id {
    //   eg: "123e4567-e89b-12d3-a456-426614174000"
    const char *id;
 } clap_universal_plugin_id_t;
+#endif // CLAP_UNIVERSAL_PLUGIN_ID_H

--- a/include/clap/version.h
+++ b/include/clap/version.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CLAP_VERSION_H
+#define CLAP_VERSION_H
 
 #include "private/macros.h"
 #include "private/std.h"
@@ -40,3 +42,4 @@ clap_version_is_compatible(const clap_version_t v) {
    // versions 0.x.y were used during development stage and aren't compatible
    return v.major >= 1;
 }
+#endif // CLAP_VERSION_H


### PR DESCRIPTION
`#pragma once` is widely supported, but it is not part of the C standard and not all C toolchains recognize it. To improve portability, this adds traditional include guards alongside the existing `#pragma once`.

I ran into issues using the headers in a Zig project with `@cInclude`, which were resolved after adding the guards. Similar problems have been reported with older versions of TCC (Fixes #466).

`#pragma once` is kept to preserve existing behavior and potential compile-time benefits on compilers that support it.

These changes don’t affect the ABI or public API and only make header inclusion more reliable across different toolchains.