### PR TITLE
Preloader extension (name TBD) for background operations

### DIFF
--- a/include/clap/all.h
+++ b/include/clap/all.h
@@ -4,10 +4,13 @@
 
 #include "factory/draft/plugin-invalidation.h"
 #include "factory/draft/plugin-state-converter.h"
+#include "factory/draft/preloader-factory.h"
 
 #include "ext/draft/extensible-audio-ports.h"
 #include "ext/draft/gain-adjustment-metering.h"
 #include "ext/draft/mini-curve-display.h"
+#include "ext/draft/preloader.h"
+#include "ext/draft/preloader-activate.h"
 #include "ext/draft/project-location.h"
 #include "ext/draft/resource-directory.h"
 #include "ext/draft/scratch-memory.h"

--- a/include/clap/clap.h
+++ b/include/clap/clap.h
@@ -34,6 +34,7 @@
 #include "plugin-features.h"
 #include "host.h"
 #include "universal-plugin-id.h"
+#include "preloader.h"
 
 #include "ext/ambisonic.h"
 #include "ext/audio-ports-activation.h"

--- a/include/clap/ext/draft/preloader-activate.h
+++ b/include/clap/ext/draft/preloader-activate.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../../preloader.h"
+
+static CLAP_CONSTEXPR const char CLAP_EXT_PRELOADER_ACTIVATE[] = "clap.preloader_activate/1";
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct clap_preloader_activate {
+   /// Prepares plugin activation for a given audio configuration.
+   ///
+   /// This may e.g. pre-allocate buffers of the appropriate size and configuration, which will
+   /// be transferred to the plugin on Commit, at which point they can be directly used in
+   /// a subsequent called to `clap_plugin.activate`, instead of having to be allocated on the main
+   /// thread.
+   ///
+   /// Note that this does *not* activate the plugin on Commit. It only transfers the pre-allocated
+   /// resources to the plugin for a subsequent `clap_plugin.activate` call.
+   ///
+   /// Returns `true` if this succeeded, or `false` if this failed.
+   ///
+   /// A `prepare_activate` failure is not fatal, it only means the plugin may have to perform
+   /// more work on the main thread during the `clap_plugin.activate` call.
+   // [preloader-thread]
+   bool(CLAP_ABI *prepare_activate)(const clap_preloader_t *preloader,
+                                    double                  sample_rate,
+                                    uint32_t                min_frames_count,
+                                    uint32_t                max_frames_count);
+} clap_preloader_activate_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/clap/ext/draft/preloader.h
+++ b/include/clap/ext/draft/preloader.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../../preloader.h"
+
+static CLAP_CONSTEXPR const char CLAP_EXT_PRELOADER[] = "clap.preloader/1";
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Allows existing plugin instances to interact with Preloaders.
+///
+/// See "preloader.h" for a detailed description of the Snapshot and Commit operations.
+///
+/// Plugin types which do not support Preloaders at all should not implement this extension.
+typedef struct clap_plugin_preloader {
+   /// Snapshots a plugin's state to a new Preloader instance.
+   ///
+   /// If this succeeds, the caller receives ownership of the returned Preloader instance, which it
+   /// must free using `clap_preloader.destroy`.
+   ///
+   /// The preloader is not allowed to use any of the provided `preloader_host` callbacks in the
+   /// `create` call.
+   ///
+   /// Returns NULL if this fails.
+   // [main-thread]
+   const clap_preloader_t *(CLAP_ABI *snapshot_to_new)(const clap_plugin_t         *plugin,
+                                                       const clap_preloader_host_t *preloader_host);
+
+   /// Snapshots a plugin's state to an existing Preloader instance.
+   ///
+   /// Returns `true` if the Snapshot operation succeeded, or `false` otherwise.
+   // [main-thread]
+   bool(CLAP_ABI *snapshot)(const clap_plugin_t *plugin, const clap_preloader_t *preloader);
+
+   /// Commits a Preloader's state into this plugin instance.
+   ///
+   /// Returns `true` if the Snapshot operation succeeded, or `false` otherwise.
+   // [main-thread]
+   bool(CLAP_ABI *commit)(const clap_plugin_t *plugin, const clap_preloader_t *preloader);
+} clap_preloader_instantiate_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/clap/ext/draft/preloader.h
+++ b/include/clap/ext/draft/preloader.h
@@ -29,11 +29,17 @@ typedef struct clap_plugin_preloader {
 
    /// Snapshots a plugin's state to an existing Preloader instance.
    ///
+   /// This function must *not* be called concurrently to any other function using the same
+   /// `clap_preloader` instance, including (but not limited to) any [preloader-thread] function.
+   ///
    /// Returns `true` if the Snapshot operation succeeded, or `false` otherwise.
    // [main-thread]
    bool(CLAP_ABI *snapshot)(const clap_plugin_t *plugin, const clap_preloader_t *preloader);
 
    /// Commits a Preloader's state into this plugin instance.
+   ///
+   /// This function must *not* be called concurrently to any other function using the same
+   /// `clap_preloader` instance, including (but not limited to) any [preloader-thread] function.
    ///
    /// Returns `true` if the Snapshot operation succeeded, or `false` otherwise.
    // [main-thread]

--- a/include/clap/ext/state.h
+++ b/include/clap/ext/state.h
@@ -43,10 +43,10 @@ typedef struct clap_host_state {
 } clap_host_state_t;
 
 typedef struct clap_plugin_preloader_state {
-   // Saves the Preloader's state into stream.
+   // Saves the given `preloader`'s state into `stream`.
    // Returns true if the state was correctly saved.
    // [preloader-thread]
-   bool(CLAP_ABI *save)(const clap_preloader_t *plugin, const clap_ostream_t *stream);
+   bool(CLAP_ABI *save)(const clap_preloader_t *preloader, const clap_ostream_t *stream);
 
    // Loads the plugin state from `stream` into `preloader`.
    // If this returns true, the load was successful, and the loaded state will be applied to the

--- a/include/clap/ext/state.h
+++ b/include/clap/ext/state.h
@@ -2,6 +2,7 @@
 
 #include "../plugin.h"
 #include "../stream.h"
+#include "../preloader.h"
 
 /// @page State
 /// @brief state management
@@ -16,6 +17,7 @@
 /// then consider implementing CLAP_EXT_STATE_CONTEXT in addition to CLAP_EXT_STATE.
 
 static CLAP_CONSTEXPR const char CLAP_EXT_STATE[] = "clap.state";
+static CLAP_CONSTEXPR const char CLAP_EXT_PRELOADER_STATE[] = "clap.state";
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +41,20 @@ typedef struct clap_host_state {
    // [main-thread]
    void(CLAP_ABI *mark_dirty)(const clap_host_t *host);
 } clap_host_state_t;
+
+typedef struct clap_plugin_preloader_state {
+   // Saves the Preloader's state into stream.
+   // Returns true if the state was correctly saved.
+   // [preloader-thread]
+   bool(CLAP_ABI *save)(const clap_preloader_t *plugin, const clap_ostream_t *stream);
+
+   // Loads the plugin state from `stream` into `preloader`.
+   // If this returns true, the load was successful, and the loaded state will be applied to the
+   // plugin instance on commit.
+   //
+   // [preloader-thread]
+   bool(CLAP_ABI *load)(const clap_preloader_t *preloader, const clap_istream_t *stream);
+} clap_plugin_preloader_state_t;
 
 #ifdef __cplusplus
 }

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -50,6 +50,31 @@ extern "C" {
 ///    provide [audio-thread] functions outside these conditions may experience inconsistent or
 ///    inaccurate rendering.
 ///
+///  preloader-thread:
+///    This thread is used by Preloaders (see preloader.h) to perform long-running, background
+///    operations that are directly requested by the host (such as state loading, saving, etc.).
+///
+///    This thread is not realtime, and unlike the main-thread it also doesn't need to remain
+///    responsive enough for user interaction, making it suitable for long-running tasks such as
+///    asset loading or blocking I/O.
+///
+///    Just like the audio-thread, this thread is symbolic. There is no one OS thread that remains
+///    the preloader-thread for either the plugin's lifetime or the Preloader's lifetime.
+///    A host may opt to have a preloader thread pool and schedule [preloader-thread] method calls
+///    on different OS threads over time.
+///    However, there cannot be two different preloader-threads for a given preloader instance at
+///    the same time, and the host must guarantee it.
+///
+///    In other words, a given preloader instance always "belongs" to a single OS thread at a time,
+///    but the host may elect to "send" that instance to any other thread (including the main
+///    thread) any time it wishes.
+///
+///    Moreover, just like with [audio-thread], functions marked with [preloader-thread] **ARE NOT
+///    CONCURRENT** for a given preloader instance. The host may mark any OS thread, including the
+///    main-thread as the preloader-thread, as long as it can guarantee that only one OS thread is
+///    the preloader-thread at a time in a preloader instance. The preloader-thread can be seen as a
+///    concurrency guard for all functions marked with [preloader-thread].
+///
 ///  Clap also tags some functions as [thread-safe]. Functions tagged as [thread-safe] can be called
 ///  from any thread unless explicitly counter-indicated (for instance [thread-safe, !audio-thread])
 ///  and may be called concurrently.

--- a/include/clap/ext/thread-check.h
+++ b/include/clap/ext/thread-check.h
@@ -10,7 +10,7 @@ extern "C" {
 
 /// @page thread-check
 ///
-/// CLAP defines two symbolic threads:
+/// CLAP defines three symbolic threads:
 ///
 /// main-thread:
 ///    This is the thread in which most of the interaction between the plugin and host happens.

--- a/include/clap/factory/draft/preloader-factory.h
+++ b/include/clap/factory/draft/preloader-factory.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../../private/macros.h"
+#include "../../preloader.h"
+
+static const CLAP_CONSTEXPR char CLAP_PLUGIN_PRELOADER_FACTORY_ID[] =
+   "clap.plugin-preloader-factory/1";
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// A Factory to create Preloaders.
+typedef struct clap_preloader_factory {
+   /// Returns `true` if a plugin type (identified by the given `plugin_id`) supports creating
+   /// a Preloader by using `clap_preloader_factory.create`.
+   ///
+   /// If this returns `false`, then using `clap_preloader_factory.create` with the same `plugin_id`
+   /// will always fail.
+   // [thread-safe]
+   bool(CLAP_ABI *plugin_supports_preloader)(const struct clap_preloader_factory *factory,
+                                             const char                          *plugin_id);
+
+   /// Creates a new Preloader for a given plugin type identified by the given `plugin_id`.
+   ///
+   /// If this succeeds, the caller receives ownership of the returned Preloader instance, which it
+   /// must free using `clap_preloader.destroy`.
+   ///
+   /// The preloader is not allowed to use any of the provided `preloader_host` callbacks in the
+   /// `create` call.
+   ///
+   /// Returns NULL if this fails, or if the given plugin type does not support Preloaders.
+   // [thread-safe]
+   const clap_preloader_t *(CLAP_ABI *create)(const struct clap_preloader_factory *factory,
+                                              const clap_preloader_host_t         *preloader_host,
+                                              const char                          *plugin_id);
+} clap_plugin_preloader_factory_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/clap/preloader.h
+++ b/include/clap/preloader.h
@@ -1,0 +1,218 @@
+#pragma once
+
+#include "private/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Preloaders are lightweight objects that allow preparing changes to plugin state
+/// asynchronously in a background thread, and then atomically committing those changes later on the
+/// main thread.
+///
+/// Preloaders can be thought of as a mirror image of plugins, except Preloaders can be manipulated
+/// in other threads, and Preloaders cannot manipulate audio or events at all.
+///
+/// Preloaders usually "belong" to a semantic thread call the Preloader Thread, and most of their
+/// methods are therefore marked as `[preloader-thread]`. See ext/thread-check.h for more details.
+///
+/// # Use case examples
+///
+/// Loading a new plugin instance (e.g. on Project load) from a background preloader thread:
+///
+/// * [preloader-thread] clap_preloader_factory.create
+/// * [preloader-thread] clap_preloader.init
+/// * [preloader-thread] clap_plugin_preloader_state.load
+/// * [preloader-thread] clap_preloader_activate.prepare_activate (optional, if supported)
+/// * [preloader-thread] clap_preloader.into_plugin
+/// * [main-thread] clap_plugin.init
+/// * [main-thread] clap_plugin.activate
+///
+/// Asynchronous loading:
+///
+/// * [preloader-thread] clap_preloader_factory.create
+/// * [preloader-thread] clap_preloader.init
+/// * [preloader-thread] clap_plugin_preloader_state.load
+/// * [main-thread] clap_plugin_preloader.commit
+/// * [preloader-thread] clap_preloader.destroy
+///
+/// Asynchronous saving:
+///
+/// * [main-thread] clap_plugin_preloader.create
+/// * [preloader-thread] clap_preloader.init
+/// * [preloader-thread] clap_plugin_preloader_state.save
+/// * [preloader-thread] clap_preloader.destroy
+///
+/// More use-cases for this interface can also be added with future extensions.
+
+/// Host-side callbacks and metadata for a preloader.
+///
+/// This can be thought as the Preloader equivalent to `clap_host`.
+typedef struct clap_preloader_host {
+   clap_version_t clap_version; // initialized to CLAP_VERSION
+
+   void *preloader_host_data; // reserved pointer for the host
+
+   /// The `name` and `version` fields are mandatory and should not be NULL nor point to empty
+   /// strings.
+   ///
+   /// These fields should have the same values as the ones provided by `clap_host`.
+   const char *name;    // eg: "Bitwig Studio"
+   const char *vendor;  // eg: "Bitwig GmbH"
+   const char *url;     // eg: "https://bitwig.com"
+   const char *version; // eg: "4.3", see plugin.h for advice on how to format the version
+
+   /// Queries an extension.
+   ///
+   /// The returned pointer is owned by the host.
+   ///
+   /// It is forbidden to call this function before `clap_preloader.init`.
+   /// Hosts may call this function during the `clap_preloader.init` call, and afterward if `init`
+   /// succeeds.
+   // [thread-safe]
+   const void *(CLAP_ABI *get_extension)(const struct clap_preloader_host *host,
+                                         const char                       *extension_id);
+} clap_preloader_host_t;
+
+/// A Preloader instance.
+///
+/// Preloader types always match Plugin types one-to-one, and as such they share the same ID.
+/// It is always an error to use a Preloader with another Plugin type than the one it is
+/// representing.
+///
+/// This is initialized and destroyed in the same manner as a `clap_plugin`, using the `init` and
+/// `destroy` functions.
+///
+/// Preloaders can be created one of two ways:
+/// * From a plugin ID, using `clap_preloader_factory.create`;
+/// * Directly from a plugin instance, using `clap_plugin_preloader.create`.
+///
+/// Once created, a Preloader's state can be modified in the background `preloader-thread`, and then
+/// applied to a plugin instance using `clap_plugin_preloader.commit`, or used to create a brand-new
+/// plugin instance with `clap_preloader.into_plugin`.
+///
+/// Note that by default, this interface provides no way to change or use a Preloader's inner state,
+/// nor does it define what that state actually is.
+///
+/// All changes and uses for a Preloader are done via Preloader Extensions, such as
+/// `clap_preloader_activate` or `clap_plugin_preloader_state`.
+/// There is no required set of extensions either hosts or plugins have to implement in order to use
+/// Preloaders.
+/// This allows hosts and plugins to pick, choose and then negotiate which operations can be
+/// offloaded to background threads.
+///
+/// All supported operations must also be supported via the "regular" [main-thread] interfaces and
+/// extensions as a fallback. E.g. if a plugin supports `clap_plugin_preloader_state`, it must also
+/// support `clap_plugin_state` as a fallback in case the host doesn't support it, with the same
+/// resulting behavior.
+///
+/// # Committing and Snapshotting
+///
+/// This specification uses the terms "Committing" and "Snapshotting" to describe the following
+/// operations:
+///
+/// * A "Commit" operation applies a Preloader instance's state to a plugin instance;
+/// * A "Snapshot" operation copies a plugin instance's state into a Provider instance.
+///
+/// Committing takes the entire state of the Preloader instance (which may have been created by the
+/// accumulation of several different operations), and transfers it all to a given Plugin instance
+/// in a single operation. When successful, a Commit operation leaves the Preloader in an "empty"
+/// state, i.e. the same state a Preloader is in when freshly created from
+/// `clap_preloader_factory.create`.
+///
+/// Committing an "empty" Preloader to any Plugin instance is always equivalent to a no-op.
+///
+/// To make the Commit operation faster, plugin implementations may transfer old, unused resources
+/// back into the Preloader for it to deallocate in another thread (when `clap_preloader.destroy`
+/// is called), rather than deallocating them in the main thread.
+///
+/// Snapshotting is the opposite operation to Committing, and takes the entire state of a Plugin
+/// instance and copies it to a Preloader instance.
+/// Snapshotting overwrites any state that the Preloader may still contain. Therefore, Snapshotting
+/// to a Preloader instance that already has e.g. state loaded, is equivalent to Snapshotting to a
+/// new, "empty" Preloader instance.
+///
+/// Snapshotting is a read-only operation for the Plugin instance, after which it may continue to
+/// process audio, receive events, etc., as usual.
+///
+/// Unlike with Committing, Snapshotting a brand-new (i.e. default) Plugin instance is not a no-op,
+/// it only results in a Preloader instance containing the "Default" preset.
+/// Note that this does *not* result in an "empty" Preloader
+///
+/// The goal of Preloaders is to move as much work as possible away from the main thread.
+/// Therefore, plugin implementations should strive to make Commit and Snapshot operations as quick
+/// as possible, and should avoid to perform any long-running operations (such as I/O).
+///
+/// Despite this however, Commit and Snapshot operations may still perform non-realtime-safe
+/// operations, such as memory allocation.
+///
+/// Committing and Snapshotting are always atomic operations. They either completely succeed, or
+/// completely fail.
+/// As such, Committing and Snapshotting cannot result in a "partial" or invalid state. A failed
+/// Commit or Snapshot is equivalent to a no-op for both the Plugin and the Preloader.
+///
+typedef struct clap_preloader {
+   /// The Plugin Descriptor of the matching Plugin type.
+   ///
+   /// This pointer may point to the same `clap_plugin_descriptor` instance as the pointer in the
+   /// matching `clap_plugin` type.
+   /// However, hosts should not rely on this to try and figure if a given preloader matches a given
+   /// plugin. They should compare the values of the descriptor's `id` fields for that.
+   const clap_plugin_descriptor_t *desc;
+
+   void *preloader_data; // reserved pointer for the preloader
+
+   /// Must be called after creating the preloader.
+   ///
+   /// Returns `true` on success, and `false` on failure.
+   /// If this succeeds, then this preloader instance is initialized and ready to be used.
+   /// If this fails, then the caller must not use any other functions on this instance, and should
+   /// `destroy` it right away.
+   ///
+   /// Only starting from within this function call (and afterward if `init` succeeds), is the
+   /// Preloader allowed to use the callbacks provided by the previously given `clap_preloader_host`
+   /// instance.
+   ///
+   /// This works in the same manner as `clap_plugin.init`.
+   // [preloader-thread]
+   bool(CLAP_ABI *init)(const struct clap_preloader *preloader);
+
+   /// Frees the Preloader and its resources.
+   // [preloader-thread]
+   void(CLAP_ABI *destroy)(const struct clap_preloader *preloader);
+
+   /// Commits into a new plugin instance by consuming the preloader.
+   ///
+   /// If this succeeds, a new clap_plugin instance is created and returned, and the preloader is
+   /// consumed.
+   ///
+   /// "Consumed" in this context means the Preloader transfers all of its allocated resources into
+   /// the plugin instance, including itself.
+   ///
+   /// If this succeeds, that means the caller must then discard the `preloader` pointer, and must
+   /// not call `clap_preloader.destroy` on it, or any other Preloader function.
+   ///
+   /// Just like with `clap_plugin_factory.create`, the plugin instance is not allowed to use the
+   /// host callbacks in this method. It must wait until clap_plugin.init is called.
+   /// Also like with `clap_plugin_factory.create`, the caller owns the newly created plugin
+   /// instance, and must free it with `clap_plugin.destroy` when it is done with it.
+   ///
+   /// This returns NULL if the Commit operation failed.
+   // [preloader-thread]
+   const clap_plugin_t *(CLAP_ABI *into_plugin)(const struct clap_preloader *preloader,
+                                                const clap_host_t           *host);
+
+   /// Queries an extension.
+   ///
+   /// The returned pointer is owned by the plugin.
+   ///
+   /// It is forbidden to call this function before `clap_preloader.init`.
+   /// Hosts may call this function during the `clap_preloader.init` call, and afterward if `init`
+   /// succeeds.
+   // [thread-safe]
+   const void *(CLAP_ABI *get_extension)(const struct clap_preloader *preloader, const char *id);
+} clap_preloader_t;
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Following the discussion in #484, this is a set of extensions (and factory) that provide a way for hosts to perform various expensive plugin operations (e.g. loading, saving, etc.) in a background thread or thread pool.

The full design is detailed in `preloader.h`, but in short, the idea is to introduce a small object that can contain the state of a plugin instance, perform the expensive work off of the main thread, and come back to the main thread only to synchronize with a plugin instance.

I've named this "Preloader" for now, but this isn't a very good name since it can do more than just pre-loading, so ideas on how to better call this are welcome. :slightly_smiling_face: 

Compared to the design in #343, this does not change the thread classes of any existing functions, nor does it "lock" the plugin instance in a "background operation" mode. This completely avoids the issues raised in #343 of e.g. using host callbacks, timers, processing, etc.
For the plugin instance, it's just business as usual until the Preloader comes in for synchronizing (i.e. Commit or Snapshot operation), which always happens on the `[main-thread]`, so no thread-switching or special synchronization is needed there.

In fact, this approach is heavily inspired by the existing rules around `[audio-thread]` operation, where this part of the plugin can "live" on a separate thread (or thread pool), but is completely non-concurrent.

This makes the implementation much easier:

* For plugins, no synchronization primitives are needed, it's just Plain Old Data internally, everything is handled by the host;
* For hosts, since this is essentially the same rules as for `[audio-thread]`, they can re-use their existing infrastructure (e.g. thread pools and channels), only for a different thread (pool) dedicated to long-running, non-realtime background operation.

On top of that, Preloaders make use of the familiar CLAP extension system to expose to the host which background operations are supported.
There is no "required" set of extensions needed to make it work, so plugins can choose to implement only what they really need to be offloaded to a background thread.

On top of the `preloader` extension and the `preloader-factory`, this PR introduces two "Preloader extensions" to start:

* `clap_plugin_preloader_state`: Allows loading & saving plugin state into/from a preloader from a background thread;
* `clap_preloader_activate`: Allows to preallocate e.g. buffers or other ressources from a background thread, to make calls to `activate` faster.

Other extensions may have "preloader" variants added in the future for background operation, here's a few ideas:
* `log`: would be helpful to have logging facilities available in background threads (we could keep the same interface there tbh)
* `state-context`: to be on-par with the current `[main-thread]` versions;
* `thread-check`
* `gui`: we could allow some GUI resources needed for `clap_gui.create` to be created/loaded in the background, e.g. assets, fonts, and possibly some GPU resources for when multithread-compatible APIs are used (e.g. Vulkan, Metal, DX12).
* More? :slightly_smiling_face: 

Also to note, I've tested and used this internally for a while, but I've only just cleaned it up a bit following the discussion in #484, so feel free to also request changes in code organization and such.