### PR TITLE
Introduce the octave-number extension

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# Changes in 1.2.8
+
+* [octave-number.h](include/clap/ext/draft/octave-number.h): new extension to share octave number of MIDI note 60 from host to plugin.
+
 # Changes in 1.2.7
 
 * [webview.h](include/clap/ext/draft/webview.h): new webview draft extensions

--- a/include/clap/ext/draft/octave-number.h
+++ b/include/clap/ext/draft/octave-number.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../../plugin.h"
+
+// This extension allows a host to communicate to a plugin the
+// octave number associated with MIDI Note 60 (aka "Middle C").
+// Since various hosts and standards call note 60 either C3, C4 or C5,
+// host displays and plugin displays often mismatch absent this information
+// being shared.
+
+static CLAP_CONSTEXPR const char CLAP_EXT_PROJECT_LOCATION[] = "clap.octave-number/1";
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct clap_plugin_octave_number {
+   // If displaying the name of a note, and using standard CDEFGAB scale note names
+   // on a piano-roll-like display, this api will tell the plugin which octave number is
+   // associated with note 60.  For instance, calling this with '3' would indicate to
+   // the plugin that the consistent name for note 60 is "C3", for 72 is "C4" etc...
+   // if using CDEFGAB note names across a 12 note display.
+   // [main-thread]
+   void(CLAP_ABI *set_note60_octave)(const clap_plugin_t                  *plugin,
+                                     int octaveNumber);
+} clap_plugin_octave_number_t;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/clap/ext/draft/octave-number.h
+++ b/include/clap/ext/draft/octave-number.h
@@ -8,7 +8,7 @@
 // host displays and plugin displays often mismatch absent this information
 // being shared.
 
-static CLAP_CONSTEXPR const char CLAP_EXT_PROJECT_LOCATION[] = "clap.octave-number/1";
+static CLAP_CONSTEXPR const char CLAP_EXT_OCTAVE_NUMBER[] = "clap.octave-number/1";
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +22,7 @@ typedef struct clap_plugin_octave_number {
    // if using CDEFGAB note names across a 12 note display.
    // [main-thread]
    void(CLAP_ABI *set_note60_octave)(const clap_plugin_t                  *plugin,
-                                     int octaveNumber);
+                                     int8_t                                octaveNumber);
 } clap_plugin_octave_number_t;
 
 #ifdef __cplusplus

--- a/include/clap/ext/draft/octave-number.h
+++ b/include/clap/ext/draft/octave-number.h
@@ -21,8 +21,8 @@ typedef struct clap_plugin_octave_number {
    // the plugin that the consistent name for note 60 is "C3", for 72 is "C4" etc...
    // if using CDEFGAB note names across a 12 note display.
    // [main-thread]
-   void(CLAP_ABI *set_note60_octave)(const clap_plugin_t                  *plugin,
-                                     int8_t                                octaveNumber);
+   void(CLAP_ABI *set_note60_octave)(const clap_plugin_t *plugin,
+                                     int8_t               octave_number);
 } clap_plugin_octave_number_t;
 
 #ifdef __cplusplus

--- a/include/clap/version.h
+++ b/include/clap/version.h
@@ -22,7 +22,7 @@ typedef struct clap_version {
 
 #define CLAP_VERSION_MAJOR 1
 #define CLAP_VERSION_MINOR 2
-#define CLAP_VERSION_REVISION 7
+#define CLAP_VERSION_REVISION 8
 
 #define CLAP_VERSION_INIT                                                                          \
    { (uint32_t)CLAP_VERSION_MAJOR, (uint32_t)CLAP_VERSION_MINOR, (uint32_t)CLAP_VERSION_REVISION }


### PR DESCRIPTION
Allowing the name of note 60 to be specified, per comments in extension header