### PR TITLE
ext: normalize thread annotation operator to '&'

### DIFF
--- a/include/clap/ext/configurable-audio-ports.h
+++ b/include/clap/ext/configurable-audio-ports.h
@@ -38,7 +38,7 @@ typedef struct clap_audio_port_configuration_request {
 
 typedef struct clap_plugin_configurable_audio_ports {
    // Returns true if the given configurations can be applied using apply_configuration().
-   // [main-thread && !active]
+   // [main-thread & !active]
    bool(CLAP_ABI *can_apply_configuration)(
       const clap_plugin_t                                *plugin,
       const struct clap_audio_port_configuration_request *requests,
@@ -52,7 +52,7 @@ typedef struct clap_plugin_configurable_audio_ports {
    // audio ports.
    //
    // Returns true if applied.
-   // [main-thread && !active]
+   // [main-thread & !active]
    bool(CLAP_ABI *apply_configuration)(const clap_plugin_t                                *plugin,
                                        const struct clap_audio_port_configuration_request *requests,
                                        uint32_t request_count);

--- a/include/clap/ext/draft/extensible-audio-ports.h
+++ b/include/clap/ext/draft/extensible-audio-ports.h
@@ -15,7 +15,7 @@ typedef struct clap_plugin_extensible_audio_ports {
    // port_type: see clap_audio_port_info.port_type for interpretation.
    // port_details: see clap_audio_port_configuration_request.port_details for interpretation.
    // Returns true on success.
-   // [main-thread && !is_active]
+   // [main-thread & !active]
    bool(CLAP_ABI *add_port)(const clap_plugin_t *plugin,
                             bool                 is_input,
                             uint32_t             channel_count,
@@ -24,7 +24,7 @@ typedef struct clap_plugin_extensible_audio_ports {
 
    // Asks the plugin to remove a port.
    // Returns true on success.
-   // [main-thread && !is_active]
+   // [main-thread & !active]
    bool(CLAP_ABI *remove_port)(const clap_plugin_t *plugin, bool is_input, uint32_t index);
 } clap_plugin_extensible_audio_ports_t;
 

--- a/include/clap/ext/voice-info.h
+++ b/include/clap/ext/voice-info.h
@@ -41,7 +41,7 @@ typedef struct clap_voice_info {
 
 typedef struct clap_plugin_voice_info {
    // gets the voice info, returns true on success
-   // [main-thread && active]
+   // [main-thread & active]
    bool(CLAP_ABI *get)(const clap_plugin_t *plugin, clap_voice_info_t *info);
 } clap_plugin_voice_info_t;
 


### PR DESCRIPTION
A few extension headers use `&&` inside the thread annotation brackets, while the rest of the repository consistently uses `&`.

This change aligns those annotations for consistency.

No functional or ABI changes.