### PR TITLE
ext/preset-load: fix stale function name in on_error comment

### DIFF
--- a/include/clap/ext/preset-load.h
+++ b/include/clap/ext/preset-load.h
@@ -24,7 +24,7 @@ typedef struct clap_plugin_preset_load {
 } clap_plugin_preset_load_t;
 
 typedef struct clap_host_preset_load {
-   // Called if clap_plugin_preset_load.load() failed.
+   // Called if clap_plugin_preset_load.from_location() failed.
    // os_error: the operating system error, if applicable. If not applicable set it to a non-error
    // value, eg: 0 on unix and Windows.
    //


### PR DESCRIPTION
In clap_host_preset_load, the on_error comment refers to clap_plugin_preset_load.load(), but the struct defines from_location().

This updates the comment to reference the correct function.

No functional or ABI changes.