### PR TITLE
ext/thread-pool: fix incorrect example code

### DIFF
--- a/include/clap/ext/thread-pool.h
+++ b/include/clap/ext/thread-pool.h
@@ -22,8 +22,8 @@
 /// {
 ///    ...
 ///    bool didComputeVoices = false;
-///    if (host_thread_pool && host_thread_pool.exec)
-///       didComputeVoices = host_thread_pool.request_exec(host, plugin, N);
+///    if (host_thread_pool && host_thread_pool->request_exec)
+///       didComputeVoices = host_thread_pool->request_exec(host, N);
 ///
 ///    if (!didComputeVoices)
 ///       for (uint32_t i = 0; i < N; ++i)


### PR DESCRIPTION
While reading thread-pool.h I noticed the example code checks an `exec` field and calls `request_exec` with an extra argument.
The actual `clap_host_thread_pool` struct only defines `request_exec(const clap_host_t *host, uint32_t num_tasks)`.

This updates the example so it matches the current API.

No functional or ABI changes.