### PR TITLE
fix(surround): fix docs referencing non-existent struct members

### DIFF
--- a/include/clap/ext/surround.h
+++ b/include/clap/ext/surround.h
@@ -12,11 +12,8 @@
 //
 // If the host decides to change the project's surround setup:
 // 1. deactivate the plugin
-// 2. host calls clap_plugin_surround->changed()
-// 3. plugin calls clap_host_surround->get_preferred_channel_map()
-// 4. plugin eventually calls clap_host_surround->changed()
-// 5. host calls clap_plugin_surround->get_channel_map() if changed
-// 6. host activates the plugin and can start processing audio
+// 2. host calls clap_plugin_surround->get_channel_map() to read the plugin's current map
+// 3. host activates the plugin and can start processing audio
 //
 // If the plugin wants to change its surround setup:
 // 1. call host->request_restart() if the plugin is active


### PR DESCRIPTION
include/clap/ext/surround.h describes a workflow using functions that don't exist in the actual structs:

clap_plugin_surround->changed() is mentioned, but the struct only has is_channel_mask_supported and get_channel_map.

clap_host_surround->get_preferred_channel_map() is mentioned, but the struct only has changed.

The documented host-initiated flow is currently impossible to implement. This PR updates the comment to reflect the actual API (deactivate -> get_channel_map -> activate).

No ABI/API changes.