### PR TITLE
Clarify process status and tail extension docs

### DIFF
--- a/include/clap/ext/tail.h
+++ b/include/clap/ext/tail.h
@@ -6,10 +6,9 @@
 ///
 /// This extension allows a plugin to specify its tail length,
 /// which is defined as the time in samples it takes for a plugin to stop producing non-silent
-/// output after receiving no non-silent input and no events (see CLAP_PROCESS_SLEEP for resume
-/// conditions).
+/// output after receiving only quiet input samples and no events.
 ///
-/// A host can use this information to determine when it is safe to stop processing without causing
+/// A host can use this information to determine when it can stop processing without causing
 /// a significant truncation of the audio output (see CLAP_PROCESS_TAIL), or to determine the total
 /// length of a track including reverb and delay tails.
 

--- a/include/clap/ext/tail.h
+++ b/include/clap/ext/tail.h
@@ -5,15 +5,13 @@
 /// @page tail
 ///
 /// This extension allows a plugin to specify its tail length,
-/// which is defined as the time it takes for a plugin to stop producing non-silent output after
-/// receiving no non-silent input and no events.
+/// which is defined as the time in samples it takes for a plugin to stop producing non-silent
+/// output after receiving no non-silent input and no events (see CLAP_PROCESS_SLEEP for resume
+/// conditions).
 ///
 /// A host can use this information to determine when it is safe to stop processing without causing
 /// a significant truncation of the audio output (see CLAP_PROCESS_TAIL), or to determine the total
 /// length of a track including reverb and delay tails.
-///
-/// Reported tail length is latency-unaware: if a plugin reports a non-zero latency, then the tail
-/// length must also include that latency (otherwise the host may truncate the output early).
 
 static CLAP_CONSTEXPR const char CLAP_EXT_TAIL[] = "clap.tail";
 

--- a/include/clap/ext/tail.h
+++ b/include/clap/ext/tail.h
@@ -2,6 +2,19 @@
 
 #include "../plugin.h"
 
+/// @page tail
+///
+/// This extension allows a plugin to specify its tail length,
+/// which is defined as the time it takes for a plugin to stop producing non-silent output after
+/// receiving no non-silent input and no events.
+///
+/// A host can use this information to determine when it is safe to stop processing without causing
+/// a significant truncation of the audio output (see CLAP_PROCESS_TAIL), or to determine the total
+/// length of a track including reverb and delay tails.
+///
+/// Reported tail length is latency-unaware: if a plugin reports a non-zero latency, then the tail
+/// length must also include that latency (otherwise the host may truncate the output early).
+
 static CLAP_CONSTEXPR const char CLAP_EXT_TAIL[] = "clap.tail";
 
 #ifdef __cplusplus

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -20,7 +20,8 @@ enum {
    CLAP_PROCESS_CONTINUE_IF_NOT_QUIET = 2,
 
    // Rely upon the plugin's tail to determine if the plugin should continue to process:
-   // - it is safe to stop processing if the last variation (see CLAP_PROCESS_SLEEP) has occurred no later than clap_plugin_tail.get samples ago
+   // - it is safe to stop processing if the last input event/variation (see CLAP_PROCESS_SLEEP for resume conditions) 
+   //   has occurred at least clap_plugin_tail.get samples ago
    // - a tail of 0 is equivalent to CLAP_PROCESS_SLEEP
    // - an infinite tail is equivalent to CLAP_PROCESS_CONTINUE
    // 

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -19,18 +19,15 @@ enum {
    // (a reasonable implementation could check if the output volume is less than a threshold for an extended period of time)
    CLAP_PROCESS_CONTINUE_IF_NOT_QUIET = 2,
 
-   // Rely upon the plugin's tail to determine if the plugin should continue to process:
-   // - it is safe to stop processing if the last input event/variation (see CLAP_PROCESS_SLEEP for resume conditions) 
-   //   has occurred at least clap_plugin_tail.get samples ago
-   // - it is safe to stop processing if no input events/variations have occurred 
-   //   since the last call to plugin->reset() or plugin->activate()
-   // - a tail of 0 is equivalent to CLAP_PROCESS_SLEEP
-   // - an infinite tail is equivalent to CLAP_PROCESS_CONTINUE
-   // 
-   // If either host or plugin do not implement the tail extension, this status is equivalent to CLAP_PROCESS_CONTINUE.
+   // Rely upon the plugin's tail to determine if the host should continue to call process.
+   //
+   // Stopping processing after at least [clap_plugin_tail.get] samples of quiet input and no events is expected to not cause significant truncation of the audio output.
+   // Calling plugin->reset() or plugin->activate() resets the tail and the plugin is expected to produce silence until the next event or variation in audio input.
+   //
+   // If the host does not support the tail extension, it is up to host to determine if it should continue processing or not.
    CLAP_PROCESS_TAIL = 3,
 
-   // Processing succeeded, it is safe to stop processing without causing a significant truncation of the audio output.
+   // Processing succeeded, stopping processing at this point is expected to not cause significant truncation of the audio output.
    //
    // Processing can be resumed by either:
    //  - a next event (note, parameter change, etc.)

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -15,14 +15,24 @@ enum {
    CLAP_PROCESS_CONTINUE = 1,
 
    // Processing succeeded, keep processing if the output is not quiet.
+   // It is entirely up to host to determine what "quiet" means 
+   // (a reasonable implementation could check if the output volume is less than a threshold for an extended period of time)
    CLAP_PROCESS_CONTINUE_IF_NOT_QUIET = 2,
 
-   // Rely upon the plugin's tail to determine if the plugin should continue to process.
-   // see clap_plugin_tail
+   // Rely upon the plugin's tail to determine if the plugin should continue to process:
+   // - it is safe to stop processing if the last variation (see CLAP_PROCESS_SLEEP) has occurred no later than clap_plugin_tail.get samples ago
+   // - a tail of 0 is equivalent to CLAP_PROCESS_SLEEP
+   // - an infinite tail is equivalent to CLAP_PROCESS_CONTINUE
+   // 
+   // If either host or plugin do not implement the tail extension, this status is equivalent to CLAP_PROCESS_CONTINUE.
    CLAP_PROCESS_TAIL = 3,
 
-   // Processing succeeded, but no more processing is required,
-   // until the next event or variation in audio input.
+   // Processing succeeded, it is safe to stop processing without causing a significant truncation of the audio output.
+   //
+   // Processing can be resumed by either:
+   //  - a next event (note, parameter change, etc.)
+   //  - a variation in audio input (a non-constant buffer or a constant buffer with a different sample value)
+   //  - a call to clap_host.request_process()
    CLAP_PROCESS_SLEEP = 4,
 };
 typedef int32_t clap_process_status;

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -22,6 +22,8 @@ enum {
    // Rely upon the plugin's tail to determine if the plugin should continue to process:
    // - it is safe to stop processing if the last input event/variation (see CLAP_PROCESS_SLEEP for resume conditions) 
    //   has occurred at least clap_plugin_tail.get samples ago
+   // - it is safe to stop processing if no input events/variations have occurred 
+   //   since the last call to plugin->reset() or plugin->activate()
    // - a tail of 0 is equivalent to CLAP_PROCESS_SLEEP
    // - an infinite tail is equivalent to CLAP_PROCESS_CONTINUE
    // 

--- a/include/clap/process.h
+++ b/include/clap/process.h
@@ -22,7 +22,7 @@ enum {
    // Rely upon the plugin's tail to determine if the host should continue to call process.
    //
    // Stopping processing after at least [clap_plugin_tail.get] samples of quiet input and no events is expected to not cause significant truncation of the audio output.
-   // Calling plugin->reset() or plugin->activate() resets the tail and the plugin is expected to produce silence until the next event or variation in audio input.
+   // Calling plugin->reset() or plugin->activate() resets the tail and the plugin is expected to produce silence until a resume condition occurs (see CLAP_PROCESS_SLEEP).
    //
    // If the host does not support the tail extension, it is up to host to determine if it should continue processing or not.
    CLAP_PROCESS_TAIL = 3,


### PR DESCRIPTION
Clarify process status related documentation in `process.h` and `ext/tail.h`, based on #486.

Unresolved questions:
- Should tail be latency-aware or not? This PR defines the tail as the amount of time in samples since last variation in the input, which implies latency-unaware-ness. This seems to be consistent with definitions given in #414. A different comment left in #486 seems to imply that you have to wait for M+N (where M is latency and N is tail) samples until the output is silent.

Corrections are appreciated!