### PR TITLE
Clarify plugin object, host object and extension object lifetimes and ownership

### DIFF
--- a/include/clap/factory/plugin-factory.h
+++ b/include/clap/factory/plugin-factory.h
@@ -21,14 +21,15 @@ typedef struct clap_plugin_factory {
    uint32_t(CLAP_ABI *get_plugin_count)(const struct clap_plugin_factory *factory);
 
    // Retrieves a plugin descriptor by its index.
+   // The descriptor is owned by the plugin and is valid until the call to clap_plugin_entry->deinit()
    // Returns null in case of error.
-   // The descriptor must not be freed.
    // [thread-safe]
    const clap_plugin_descriptor_t *(CLAP_ABI *get_plugin_descriptor)(
       const struct clap_plugin_factory *factory, uint32_t index);
 
    // Create a clap_plugin by its plugin_id.
-   // The returned pointer must be freed by calling plugin->destroy(plugin);
+   // The clap_host pointer must be valid until after the call to plugin->destroy(plugin).
+   // The returned pointer is owned by the plugin and must be freed by calling plugin->destroy(plugin);
    // The plugin is not allowed to use the host callbacks in the create method.
    // Returns null in case of error.
    // [thread-safe]

--- a/include/clap/host.h
+++ b/include/clap/host.h
@@ -17,8 +17,8 @@ typedef struct clap_host {
    const char *url;     // eg: "https://bitwig.com"
    const char *version; // eg: "4.3", see plugin.h for advice on how to format the version
 
-   // Query an extension.
-   // The returned pointer is owned by the host.
+   // Query an extension, returns null if not supported.
+   // The returned pointer is owned by the host and is valid until after the call to plugin->destroy()
    // It is forbidden to call it before plugin->init().
    // You can call it within plugin->init() call, and after.
    // [thread-safe]

--- a/include/clap/plugin.h
+++ b/include/clap/plugin.h
@@ -46,7 +46,7 @@ typedef struct clap_plugin {
    // Must be called after creating the plugin.
    // If init returns false, the host must destroy the plugin instance.
    // If init returns true, then the plugin is initialized and in the deactivated state.
-   // Unlike in `plugin-factory::create_plugin`, in init you have complete access to the host 
+   // Unlike in `plugin-factory::create_plugin`, in init you have complete access to the host
    // and host extensions, so clap related setup activities should be done here rather than in
    // create_plugin.
    // [main-thread]
@@ -96,8 +96,8 @@ typedef struct clap_plugin {
    clap_process_status(CLAP_ABI *process)(const struct clap_plugin *plugin,
                                           const clap_process_t     *process);
 
-   // Query an extension.
-   // The returned pointer is owned by the plugin.
+   // Query an extension, returns null if not supported.
+   // The returned pointer is owned by the plugin and is valid until the call to plugin->destroy().
    // It is forbidden to call it before plugin->init().
    // You can call it within plugin->init() call, and after.
    // [thread-safe]


### PR DESCRIPTION
Add ownership and lifetime comments to `clap_host::get_extension`, `clap_plugin::get_extension` and `clap_plugin_factory::create_plugin` based on the discussion in #414 