### PR TITLE
Clarify bypass parameter count and process() behavior

### DIFF
--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -150,6 +150,9 @@ enum {
    // Only zero or one bypass parameter is allowed per plugin.
    // min: 0 -> bypass off
    // max: 1 -> bypass on
+   // The value of this parameter should not influence whether the host calls plugin->process() or
+   // not. If a plugin wants to save CPU cycles during bypass, the plugin will implement that in its
+   // process() routine, possibly returning CLAP_PROCESS_SLEEP at some point.
    CLAP_PARAM_IS_BYPASS = 1 << 4,
 
    // When set:

--- a/include/clap/ext/params.h
+++ b/include/clap/ext/params.h
@@ -147,6 +147,7 @@ enum {
 
    // This parameter is used to merge the plugin and host bypass button.
    // It implies that the parameter is stepped.
+   // Only zero or one bypass parameter is allowed per plugin.
    // min: 0 -> bypass off
    // max: 1 -> bypass on
    CLAP_PARAM_IS_BYPASS = 1 << 4,


### PR DESCRIPTION
This PR clarifies that there can only be zero or one bypass parameter per plugin and that the value of the bypass parameter should not influence the host calling plugin->process() or not.